### PR TITLE
Fix issue with dist build allowing recursive dir create

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,35 +2,43 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "node",
+      "type": "pwa-node",
       "request": "launch",
       "name": "Mocha All tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/mocha",
       "cwd": "${workspaceFolder}",
       "args": [
-        "--require", "ts-node/register",
-        "-u", "bdd",
-        "--timeout", "999999",
+        "--require",
+        "ts-node/register",
+        "-u",
+        "bdd",
+        "--timeout",
+        "--colors",
+        "999999",
         "src/test/**/*.ts"
       ],
       "internalConsoleOptions": "neverOpen"
     },
     {
-      "type": "node",
+      "type": "pwa-node",
       "request": "launch",
       "name": "Mocha Current File",
       "program": "${workspaceFolder}/node_modules/mocha/bin/mocha",
       "cwd": "${workspaceFolder}",
       "args": [
-        "--require", "ts-node/register",
-        "-u", "bdd",
-        "--timeout", "999999",
+        "--require",
+        "ts-node/register",
+        "-u",
+        "bdd",
+        "--colors",
+        "--timeout",
+        "999999",
         "${file}"
       ],
       "internalConsoleOptions": "neverOpen"
     },
     {
-      "type": "node",
+      "type": "pwa-node",
       "request": "launch",
       "name": "Launch current TypeScript src",
       "program": "${file}",
@@ -42,7 +50,7 @@
       "sourceMaps": true
     },
     {
-      "type": "node",
+      "type": "pwa-node",
       "request": "launch",
       "name": "Gulp task",
       "program": "${workspaceFolder}/node_modules/gulp/bin/gulp.js",

--- a/gulp/dist.js
+++ b/gulp/dist.js
@@ -31,7 +31,7 @@ module.exports = async () => {
       rm(extensionBinFolder, { recursive: true }, resolve)
     );
   }
-  await mkdir(extensionBinFolder);
+  await mkdir(extensionBinFolder,  {recursive: true});
   await writeJson(resolve(extensionBinFolder, "vss-extension.json"), manifest, {
     spaces: 2,
   });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.2.14",
-    "@types/mocha": "^8.0.3",
+    "@types/mocha": "^8.2.2",
     "@types/node": "^14.14.6",
     "@typescript-eslint/eslint-plugin": "^4.6.1",
     "@typescript-eslint/parser": "^4.6.1",
@@ -34,7 +34,7 @@
     "gulp-mocha": "^7.0.2",
     "gulp-sourcemaps": "^2.6.5",
     "gulp-typescript": "^6.0.0-alpha.1",
-    "mocha": "^8.2.1",
+    "mocha": "^8.3.2",
     "node-fetch": "^2.6.1",
     "ps-list": "^7.2.0",
     "tfx-cli": "^0.8.3",


### PR DESCRIPTION
Error:

$ gulp dist
[14:49:12] Using gulpfile ~\Documents\Repositories\powerplatform-build-tools\gulpfile.js
[14:49:12] Starting 'dist'...
[14:49:12] 'dist' errored after 3.52 ms
[14:49:12] Error: ENOENT: no such file or directory, mkdir 'C:\Users\<USER>\Documents\Repositories\powerplatform-build-tools\bin\extension'

Fixed by allowing recursive directory creation.