### PR TITLE
npm audit fix to address e.g. latest tfx-cli patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -828,9 +828,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -4790,6 +4790,50 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/gulp-cli": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
+      "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^1.0.1",
+        "archy": "^1.0.0",
+        "array-sort": "^1.0.0",
+        "color-support": "^1.1.3",
+        "concat-stream": "^1.6.0",
+        "copy-props": "^2.0.1",
+        "fancy-log": "^1.3.2",
+        "gulplog": "^1.0.0",
+        "interpret": "^1.4.0",
+        "isobject": "^3.0.1",
+        "liftoff": "^3.1.0",
+        "matchdep": "^2.0.0",
+        "mute-stdout": "^1.0.0",
+        "pretty-hrtime": "^1.0.0",
+        "replace-homedir": "^1.0.0",
+        "semver-greatest-satisfied-range": "^1.1.0",
+        "v8flags": "^3.2.0",
+        "yargs": "^7.1.0"
+      },
+      "bin": {
+        "gulp": "bin/gulp.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/gulp-cli/node_modules/ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-wrap": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/gulp-eslint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-6.0.0.tgz",
@@ -5629,50 +5673,6 @@
         "readable-stream": "2 || 3"
       }
     },
-    "node_modules/gulp/node_modules/ansi-colors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
-      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-wrap": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gulp/node_modules/gulp-cli": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
-      "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^1.0.1",
-        "archy": "^1.0.0",
-        "array-sort": "^1.0.0",
-        "color-support": "^1.1.3",
-        "concat-stream": "^1.6.0",
-        "copy-props": "^2.0.1",
-        "fancy-log": "^1.3.2",
-        "gulplog": "^1.0.0",
-        "interpret": "^1.4.0",
-        "isobject": "^3.0.1",
-        "liftoff": "^3.1.0",
-        "matchdep": "^2.0.0",
-        "mute-stdout": "^1.0.0",
-        "pretty-hrtime": "^1.0.0",
-        "replace-homedir": "^1.0.0",
-        "semver-greatest-satisfied-range": "^1.1.0",
-        "v8flags": "^3.2.0",
-        "yargs": "^7.1.0"
-      },
-      "bin": {
-        "gulp": "bin/gulp.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
@@ -5921,9 +5921,9 @@
       }
     },
     "node_modules/i": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
-      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
       "dev": true,
       "engines": {
         "node": ">=0.4"
@@ -10630,9 +10630,9 @@
       "dev": true
     },
     "node_modules/tfx-cli": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.9.2.tgz",
-      "integrity": "sha512-//TwhDpxuog4RwbQ31fQDmzLEBIBXsBhoV+tSVHtkqlTOOTMn52eNOVkTDcsH35fttQstrNEvOFM6pCCo2jx3w==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.9.3.tgz",
+      "integrity": "sha512-9f5iWGAs3wSNBEgyQB8K0RyhdGNPQp5CuJ0xHOxye1F8cmkMRxGyh5s+0yIJY0NMGDC/aA7Kb1NirBHj/3G4Vw==",
       "dev": true,
       "dependencies": {
         "app-root-path": "1.0.0",
@@ -13119,9 +13119,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -16430,6 +16430,32 @@
         "gulp-cli": "^2.2.0",
         "undertaker": "^1.2.1",
         "vinyl-fs": "^3.0.0"
+      }
+    },
+    "gulp-cli": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
+      "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^1.0.1",
+        "archy": "^1.0.0",
+        "array-sort": "^1.0.0",
+        "color-support": "^1.1.3",
+        "concat-stream": "^1.6.0",
+        "copy-props": "^2.0.1",
+        "fancy-log": "^1.3.2",
+        "gulplog": "^1.0.0",
+        "interpret": "^1.4.0",
+        "isobject": "^3.0.1",
+        "liftoff": "^3.1.0",
+        "matchdep": "^2.0.0",
+        "mute-stdout": "^1.0.0",
+        "pretty-hrtime": "^1.0.0",
+        "replace-homedir": "^1.0.0",
+        "semver-greatest-satisfied-range": "^1.1.0",
+        "v8flags": "^3.2.0",
+        "yargs": "^7.1.0"
       },
       "dependencies": {
         "ansi-colors": {
@@ -16439,32 +16465,6 @@
           "dev": true,
           "requires": {
             "ansi-wrap": "^0.1.0"
-          }
-        },
-        "gulp-cli": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
-          "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
-          "dev": true,
-          "requires": {
-            "ansi-colors": "^1.0.1",
-            "archy": "^1.0.0",
-            "array-sort": "^1.0.0",
-            "color-support": "^1.1.3",
-            "concat-stream": "^1.6.0",
-            "copy-props": "^2.0.1",
-            "fancy-log": "^1.3.2",
-            "gulplog": "^1.0.0",
-            "interpret": "^1.4.0",
-            "isobject": "^3.0.1",
-            "liftoff": "^3.1.0",
-            "matchdep": "^2.0.0",
-            "mute-stdout": "^1.0.0",
-            "pretty-hrtime": "^1.0.0",
-            "replace-homedir": "^1.0.0",
-            "semver-greatest-satisfied-range": "^1.1.0",
-            "v8flags": "^3.2.0",
-            "yargs": "^7.1.0"
           }
         }
       }
@@ -17353,9 +17353,9 @@
       "dev": true
     },
     "i": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
-      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
       "dev": true
     },
     "iconv-lite": {
@@ -21188,9 +21188,9 @@
       "dev": true
     },
     "tfx-cli": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.9.2.tgz",
-      "integrity": "sha512-//TwhDpxuog4RwbQ31fQDmzLEBIBXsBhoV+tSVHtkqlTOOTMn52eNOVkTDcsH35fttQstrNEvOFM6pCCo2jx3w==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.9.3.tgz",
+      "integrity": "sha512-9f5iWGAs3wSNBEgyQB8K0RyhdGNPQp5CuJ0xHOxye1F8cmkMRxGyh5s+0yIJY0NMGDC/aA7Kb1NirBHj/3G4Vw==",
       "dev": true,
       "requires": {
         "app-root-path": "1.0.0",


### PR DESCRIPTION
packages flagged by npm audit all root back to either tfx-cli or gulp. Unfortunately, there have been made no updates to either of those tools. Somewhat saving grace is that both are used at build time only, and are NOT used at runtime of the tasks.