### PR TITLE
Support for environment parameter to non-crud tasks

### DIFF
--- a/src/tasks/apply-solution-upgrade/apply-solution-upgrade-v0/task.json
+++ b/src/tasks/apply-solution-upgrade/apply-solution-upgrade-v0/task.json
@@ -51,6 +51,14 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
+      "name": "Environment",
+      "label": "Environment Url",
+      "type": "string",
+      "defaultValue": "$(BuildTools.EnvironmentUrl)",
+      "required": false,
+      "helpMarkDown": "Environment url this task targets; default is the pipeline variable that e.g. the CreateEnvironment task has set before."
+    },
+    {
       "name": "SolutionName",
       "label": "Solution Name",
       "type": "string",

--- a/src/tasks/checker/checker-v0/task.json
+++ b/src/tasks/checker/checker-v0/task.json
@@ -36,7 +36,14 @@
       "required": true,
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
-
+    {
+      "name": "Environment",
+      "label": "Environment Url",
+      "type": "string",
+      "defaultValue": "$(BuildTools.EnvironmentUrl)",
+      "required": false,
+      "helpMarkDown": "Environment url this task targets; default is the pipeline variable that e.g. the CreateEnvironment task has set before."
+    },
     {
       "name": "UseDefaultPACheckerEndpoint",
       "label": "Use default Power Apps Checker endpoint",

--- a/src/tasks/delete-solution/delete-solution-v0/task.json
+++ b/src/tasks/delete-solution/delete-solution-v0/task.json
@@ -51,6 +51,14 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
+      "name": "Environment",
+      "label": "Environment Url",
+      "type": "string",
+      "defaultValue": "$(BuildTools.EnvironmentUrl)",
+      "required": false,
+      "helpMarkDown": "Environment url this task targets; default is the pipeline variable that e.g. the CreateEnvironment task has set before."
+    },
+    {
       "name": "SolutionName",
       "label": "Solution Name",
       "type": "string",

--- a/src/tasks/deploy-package/deploy-package-v0/task.json
+++ b/src/tasks/deploy-package/deploy-package-v0/task.json
@@ -51,6 +51,14 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
+      "name": "Environment",
+      "label": "Environment Url",
+      "type": "string",
+      "defaultValue": "$(BuildTools.EnvironmentUrl)",
+      "required": false,
+      "helpMarkDown": "Environment url this task targets; default is the pipeline variable that e.g. the CreateEnvironment task has set before."
+    },
+    {
       "name": "PackageFile",
       "label": "Package File",
       "type": "string",

--- a/src/tasks/download-paportal/download-paportal-v0/task.json
+++ b/src/tasks/download-paportal/download-paportal-v0/task.json
@@ -42,6 +42,14 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with username/password. Does not support MFA."
     },
     {
+      "name": "Environment",
+      "label": "Environment Url",
+      "type": "string",
+      "defaultValue": "$(BuildTools.EnvironmentUrl)",
+      "required": false,
+      "helpMarkDown": "Environment url this task targets; default is the pipeline variable that e.g. the CreateEnvironment task has set before."
+    },
+    {
       "name": "DownloadPath",
       "type": "filePath",
       "label": "Download path",

--- a/src/tasks/export-solution/export-solution-v0/task.json
+++ b/src/tasks/export-solution/export-solution-v0/task.json
@@ -58,6 +58,14 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
+      "name": "Environment",
+      "label": "Environment Url",
+      "type": "string",
+      "defaultValue": "$(BuildTools.EnvironmentUrl)",
+      "required": false,
+      "helpMarkDown": "Environment url this task targets; default is the pipeline variable that e.g. the CreateEnvironment task has set before."
+    },
+    {
       "name": "SolutionName",
       "label": "Solution Name",
       "type": "string",

--- a/src/tasks/import-solution/import-solution-v0/task.json
+++ b/src/tasks/import-solution/import-solution-v0/task.json
@@ -58,6 +58,14 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
+      "name": "Environment",
+      "label": "Environment Url",
+      "type": "string",
+      "defaultValue": "$(BuildTools.EnvironmentUrl)",
+      "required": false,
+      "helpMarkDown": "Environment url this task targets; default is the pipeline variable that e.g. the CreateEnvironment task has set before."
+    },
+    {
       "name": "SolutionInputFile",
       "label": "Solution Input File",
       "type": "filePath",

--- a/src/tasks/publish-customizations/publish-customizations-v0/task.json
+++ b/src/tasks/publish-customizations/publish-customizations-v0/task.json
@@ -49,6 +49,14 @@
       "required": true,
       "visibleRule": "authenticationType = PowerPlatformSPN",
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
+    },
+    {
+      "name": "Environment",
+      "label": "Environment Url",
+      "type": "string",
+      "defaultValue": "$(BuildTools.EnvironmentUrl)",
+      "required": false,
+      "helpMarkDown": "Environment url this task targets; default is the pipeline variable that e.g. the CreateEnvironment task has set before."
     }
   ],
   "execution": {

--- a/src/tasks/upload-paportal/upload-paportal-v0/task.json
+++ b/src/tasks/upload-paportal/upload-paportal-v0/task.json
@@ -54,6 +54,14 @@
       "label": "Name of deployment profile",
       "required": false,
       "helpMarkDown": "Deployment profile name to be used. Defaults to default"
+    },
+    {
+      "name": "Environment",
+      "label": "Environment Url",
+      "type": "string",
+      "defaultValue": "$(BuildTools.EnvironmentUrl)",
+      "required": false,
+      "helpMarkDown": "Environment url this task targets; default is the pipeline variable that e.g. the CreateEnvironment task has set before."
     }
   ],
   "execution": {


### PR DESCRIPTION
Added support for non-crud tasks to pick environment parameter, but it will be displayed as environment url since create environment only supports url, thereby to avoid any confusion.

![image](https://user-images.githubusercontent.com/71529413/145654141-63408a5f-7e5f-417f-87b7-e3819d05afe5.png)

![image](https://user-images.githubusercontent.com/71529413/145654181-2eb7cac3-f46f-4d02-b715-2a25f0e85a9e.png)
