### PR TITLE
Fix environment url output variable propagation and resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,20 +11,23 @@
         "@microsoft/powerplatform-cli-wrapper",
         "@types/fs-extra",
         "azure-pipelines-task-lib",
-        "fs-extra"
+        "fs-extra",
+        "semver"
       ],
       "license": "MIT",
       "dependencies": {
         "@microsoft/powerplatform-cli-wrapper": "^0.1.38",
         "@types/fs-extra": "^9.0.13",
         "azure-pipelines-task-lib": "^3.1.0",
-        "fs-extra": "^9.0.1"
+        "fs-extra": "^9.0.1",
+        "semver": "^7.3.5"
       },
       "devDependencies": {
         "@types/chai": "^4.2.14",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.36",
         "@types/q": "^1.5.4",
+        "@types/semver": "^7.3.9",
         "@types/sinon": "^9.0.11",
         "@types/sinon-chai": "^3.2.5",
         "@types/sinonjs__fake-timers": "^6.0.2",
@@ -492,6 +495,12 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "inBundle": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+      "dev": true
     },
     "node_modules/@types/sinon": {
       "version": "9.0.11",
@@ -7507,7 +7516,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
+      "inBundle": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -10368,7 +10377,7 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
+      "inBundle": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -12969,7 +12978,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "inBundle": true
     },
     "node_modules/yargs": {
       "version": "7.1.2",
@@ -13607,6 +13616,12 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+      "dev": true
     },
     "@types/sinon": {
       "version": "9.0.11",
@@ -19122,7 +19137,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -21313,7 +21327,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -23386,8 +23399,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.14.36",
     "@types/q": "^1.5.4",
+    "@types/semver": "^7.3.9",
     "@types/sinon": "^9.0.11",
     "@types/sinon-chai": "^3.2.5",
     "@types/sinonjs__fake-timers": "^6.0.2",
@@ -72,7 +73,8 @@
     "@microsoft/powerplatform-cli-wrapper": "^0.1.38",
     "@types/fs-extra": "^9.0.13",
     "azure-pipelines-task-lib": "^3.1.0",
-    "fs-extra": "^9.0.1"
+    "fs-extra": "^9.0.1",
+    "semver": "^7.3.5"
   },
   "bundleDependencies": true
 }

--- a/src/host/PipelineVariables.ts
+++ b/src/host/PipelineVariables.ts
@@ -1,7 +1,60 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import * as tl from 'azure-pipelines-task-lib/task';
+import semver = require('semver');
+
+const agentVersion = tl.getVariable('Agent.Version') || '1.95.0'; // assume lowest agent version from task.json files
+const hasTaskVars = semver.lt(agentVersion, '2.115.0');
+
 // for backwards compat, keep env var names the same as what shipped in PS implementation:
 // see: https://dev.azure.com/dynamicscrm/OneCRM/_git/PowerApps.AzDevOpsExtensions?path=/src/extension/common/PipelineVariables.ps1
 export const EnvUrlVariableName = "BuildTools.EnvironmentUrl";
 export const EnvIdVariableName = "BuildTools.EnvironmentId";
+
+export function SetPipelineOutputVariable(varName: string, value: string): void {
+  tl.setVariable(varName, value, false, true);
+}
+
+export function GetPipelineVariable(varName: string): string | undefined {
+  let value;
+  if (hasTaskVars) {
+    // NOTE: tl.getTaskVariable is only supported on newer agents >= 2.115.0, but our task.json still allow for agents 1.9.x
+    value = tl.getTaskVariable(varName);
+  }
+  // try looking for plain pipeline variable:
+  if (!value) {
+    value = tl.getVariable(varName);
+  }
+  return value;
+}
+
+export function GetPipelineOutputVariable(varName: string): [string | undefined, string | undefined] {
+  let value = GetPipelineVariable(varName);
+  if (!value) {
+    // now try different specific task sources of ours, starting with the CreateEnvironment task:
+    const ppbtTaskOutVarOrigins = [ 'PowerPlatformCreateEnvironment' ];
+
+    for (const taskName of ppbtTaskOutVarOrigins) {
+      value = tl.getVariable(varName);
+      if (value) {
+        return [value, undefined];
+      }
+      const canonicalVarName = varName.replace(/\./g, '_').replace(/-/g, '_');
+      value = tl.getVariable(`${taskName}_${canonicalVarName}`);
+      if (value) {
+        return [value, taskName];
+      }
+    }
+  }
+  return [value, undefined];
+}
+
+export function IsolateVariableReference(refExpression: string): [string, boolean] {
+  const extractVarNameRegex = /\$\((\S+)\)/gm;
+  const m = extractVarNameRegex.exec(refExpression);
+  const isRefExpression = m !== null;
+  const result = (isRefExpression) ? m[1] : refExpression;
+  tl.debug(`IsolateVarRef: ${refExpression} -> ${result} (isRefExpression=${isRefExpression})`);
+  return [result, isRefExpression];
+}

--- a/src/params/auth/getEnvironmentUrl.ts
+++ b/src/params/auth/getEnvironmentUrl.ts
@@ -4,41 +4,56 @@
 import * as tl from 'azure-pipelines-task-lib/task';
 import getAuthenticationType from './getAuthenticationType';
 import { getEndpointName } from './getEndpointName';
-import { EnvUrlVariableName } from '../../host/PipelineVariables';
+import { EnvUrlVariableName, GetPipelineOutputVariable, IsolateVariableReference } from '../../host/PipelineVariables';
 
 
 export function getEnvironmentUrl(): string {
-  // try reading the optional task input parameter "environment"
-  let endpointUrl = tl.getInput('Environment', false);
+  const explicitEnvInputParamName = 'Environment';
+  let variableName = EnvUrlVariableName;
+
+  // try reading the optional, but explicit task input parameter "Environment"
+  let endpointUrl = tl.getInput(explicitEnvInputParamName, false);
   if (endpointUrl) {
-    console.log(`Fetched environment url from customer: ${endpointUrl}`);
-    tl.debug(`Discovered environment url from customer: ${endpointUrl}`);
+    log(`Discovered environment url from explicit input parameter '${explicitEnvInputParamName}': ${endpointUrl}`);
+    let varReferenceCandidate: string;
+    let isRefExpr: boolean;
+    // eslint-disable-next-line prefer-const
+    [varReferenceCandidate, isRefExpr] = IsolateVariableReference(endpointUrl);
+    if (isRefExpr) {
+      variableName = varReferenceCandidate;
+      log(`Discovered Azure DevOps variable expression that needs resolving: ${endpointUrl} -> ${variableName}`);
+      endpointUrl = undefined;
+    } else {
+      endpointUrl = varReferenceCandidate;
+    }
   }
 
   // try finding the environment url that should be used for the calling task in this order:
   // - check for pipeline/task variables (typically set by e.g. createEnv task)
   if (!endpointUrl) {
-    endpointUrl = tl.getVariable(EnvUrlVariableName);
+    let taskName: string | undefined;
+    [endpointUrl, taskName] = GetPipelineOutputVariable(variableName);
+    if (endpointUrl) {
+      if (taskName) {
+        log(`Discovered environment url as task output variable (${taskName} - ${variableName}): ${endpointUrl}`);
+      } else {
+        log(`Discovered environment url as pipeline/task variable (${variableName}): ${endpointUrl}`);
+      }
+    }
   }
+
+  // - try named OS environment variable:
   if (!endpointUrl) {
-    endpointUrl = tl.getTaskVariable(EnvUrlVariableName);
-  }
-  if (endpointUrl) {
-    console.log(`Discovered environment url as pipeline/task variable (${EnvUrlVariableName}): ${endpointUrl}`);
-    tl.debug(`Discovered environment url as pipeline/task variable (${EnvUrlVariableName}): ${endpointUrl}`);
-  } else {
-    endpointUrl = process.env[EnvUrlVariableName];
-  }
-  if (endpointUrl) {
-    console.log(`Discovered environment url as OS environment variable (${EnvUrlVariableName}): ${endpointUrl}`);
-    tl.debug(`Discovered environment url as OS environment variable (${EnvUrlVariableName}): ${endpointUrl}`);
+    endpointUrl = process.env[variableName];
+    if (endpointUrl) {
+      log(`Discovered environment url as OS environment variable (${variableName}): ${endpointUrl}`);
+    }
   }
 
   // - finally, fall back to use the env url that is part of the Azure DevOps service connection (i.e. called endpoint in the SDK here)
   if (!endpointUrl) {
     endpointUrl = readEnvUrlFromServiceConnection();
-    console.log(`Falling back to url from service connection: ${endpointUrl}`);
-    tl.debug(`Falling back to url from service connection: ${endpointUrl}`);
+    log(`Falling back to url from service connection, using: ${endpointUrl}`);
   }
   return endpointUrl;
 }
@@ -55,4 +70,9 @@ function readEnvUrlFromServiceConnection(): string {
     throw new Error(`Could not find endpoint url for: ${endpointName}`);
   }
   return url;
+}
+
+function log(message: string): void {
+    console.log(message);
+    tl.debug(message);
 }

--- a/src/tasks/create-environment/create-environment-v0/index.ts
+++ b/src/tasks/create-environment/create-environment-v0/index.ts
@@ -10,7 +10,7 @@ import { getCredentials } from "../../../params/auth/getCredentials";
 import { AzurePipelineTaskDefiniton } from "../../../parser/AzurePipelineDefinitions";
 import * as taskDefinitionData from "../../create-environment/create-environment-v0/task.json";
 import { BuildToolsRunnerParams } from "../../../host/BuildToolsRunnerParams";
-import { EnvIdVariableName, EnvUrlVariableName } from "../../../host/PipelineVariables";
+import { EnvIdVariableName, EnvUrlVariableName, SetPipelineOutputVariable } from "../../../host/PipelineVariables";
 
 (async () => {
   if (isRunningOnAgent()) {
@@ -38,6 +38,7 @@ export async function main(): Promise<void> {
   if (!createResult.environmentUrl || !createResult.environmentId) {
     return tl.setResult(tl.TaskResult.SucceededWithIssues, 'CreateEnvironment call did NOT return the expected environment URL!');
   }
-  tl.setVariable(EnvUrlVariableName, createResult.environmentUrl);
-  tl.setVariable(EnvIdVariableName, createResult.environmentId);
+  // set output variables:
+  SetPipelineOutputVariable(EnvUrlVariableName, createResult.environmentUrl);
+  SetPipelineOutputVariable(EnvIdVariableName, createResult.environmentId);
 }

--- a/test/getEnvironmentUrl.test.ts
+++ b/test/getEnvironmentUrl.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { expect, should, use } from "chai";
+import * as sinon from "sinon";
+import * as tl from 'azure-pipelines-task-lib/task';
+import { getEnvironmentUrl } from "../src/params/auth/getEnvironmentUrl";
+import { EnvUrlVariableName } from "../src/host/PipelineVariables";
+
+should();
+
+const testEnvUrl = 'https://ppdevtools.crm.dynamics.com/';
+
+describe("getEnvironmentUrl tests", () => {
+  const tlStub = sinon.stub(tl);
+
+  beforeEach(() => {
+    sinon.reset();
+    tlStub.getInput
+      .withArgs('authenticationType')
+      .throws(new Error('Should never reach fallthrough to ServiceConnection!!'));
+  });
+
+  it("can read explicit task input parameter with literal url", () => {
+    tlStub.getInput
+      .withArgs('Environment')
+      .returns(testEnvUrl);
+
+    const result = getEnvironmentUrl();
+    validateEnvUrl(result);
+  });
+
+  it("can read explicit task input parameter with AzDO variable expression", () => {
+    tlStub.getInput
+      .withArgs('Environment')
+      .returns('$(BuildTools.EnvironmentUrl)');
+    tlStub.getVariable
+      .withArgs('BuildTools.EnvironmentUrl')
+      .returns(testEnvUrl);
+
+    const result = getEnvironmentUrl();
+    validateEnvUrl(result);
+  });
+
+  it("can read explicit task input parameter with user defined AzDO variable expression", () => {
+    const myVarName = 'ThisIsMyPipelineVariableName';
+    tlStub.getInput
+      .withArgs('Environment')
+      .returns(`$(${myVarName})`);
+    tlStub.getVariable
+      .withArgs(myVarName)
+      .returns(testEnvUrl);
+
+    const result = getEnvironmentUrl();
+    validateEnvUrl(result);
+  });
+
+  it("can read from pipeline variable", () => {
+    tlStub.getVariable
+      .withArgs(EnvUrlVariableName)
+      .returns(testEnvUrl);
+    const result = getEnvironmentUrl();
+    validateEnvUrl(result);
+  });
+
+  it("can read CreateEnvironment task's output pipeline variable", () => {
+    tlStub.getVariable
+      .withArgs('PowerPlatformCreateEnvironment_BuildTools_EnvironmentUrl')
+      .returns(testEnvUrl);
+    const result = getEnvironmentUrl();
+    validateEnvUrl(result);
+  });
+
+  it("can fallback to reading url from service connection", () => {
+    const authType = 'PowerPlatformSPN';
+    tlStub.getInput
+      .withArgs('authenticationType')
+      .returns(authType)
+      .withArgs(authType)
+      .returns('PP_SPN');
+    tlStub.getEndpointUrl
+      .withArgs('PP_SPN', false)
+      .returns(testEnvUrl);
+    const result = getEnvironmentUrl();
+    validateEnvUrl(result);
+  });
+});
+
+function validateEnvUrl(result: string) {
+  result.should.be.a('string');
+  result.should.not.be.empty;
+
+  let url: URL = new URL('http://invalid');
+  expect(() => url = new URL(result)).to.not.throw(TypeError);
+  url.toString().should.equal(testEnvUrl);
+}


### PR DESCRIPTION
- CreateEnvironment task now sets proper AzDO output variables (both for url and envId)
- fix getEnvironmentUrl() to correctly discover output variables
- it now also resolves AzDO variable expressions $(variablrName)

work items:
- [AB#2552250](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2552250) PP-BT (new) - create env is not setting pipeline task variable EnvironmentUrl
- [AB#2571864](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2571864) getEnvironmentUrl is unable to parse value 