### PR TITLE
npm fix to unblock pipeline

### DIFF
--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-
+          - ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -33,11 +33,8 @@ jobs:
 
       - name: Build and test
         run: |
-          npm cache clean --force
-          npm install -g npm@latest --force
-          npm cache clean --force
           npm config set //npm.pkg.github.com/:_authToken=${{ secrets.GPR_ACCESS_TOKEN }}
-          npm i -g npm
+          npm i -g npm@'8.1.2'
           npm i
           npm run ci
         # Note: To set version:

--- a/src/host/BuildToolsHost.ts
+++ b/src/host/BuildToolsHost.ts
@@ -12,7 +12,6 @@ export class BuildToolsHost implements IHostAbstractions {
     if(entry.name === 'Environment')
       return getEnvironmentUrl();
 
-
     const value = tl.getInput(entry.name, entry.required);
     // normalize value to always be undefined if the user has not declared the input value
     return (value && value.trim() !== '') ? value : undefined;


### PR DESCRIPTION
npm latest version has some regression which is failing our pipeline. npm install task is failing as part of our pr loop tests, making npm to install an older version which is working as expected.