### PR TITLE
[main] back-compat for checker task: authenticationType is not always…

### DIFF
--- a/src/params/auth/getAuthenticationType.ts
+++ b/src/params/auth/getAuthenticationType.ts
@@ -4,8 +4,11 @@ export type AuthenticationType =
   | "PowerPlatformEnvironment"
   | "PowerPlatformSPN";
 
-export default function getAuthenticationType(): AuthenticationType {
+export function getAuthenticationType(defaultAuthType?: AuthenticationType): AuthenticationType {
   const authenticationType = getInput("authenticationType");
+  if (!authenticationType && defaultAuthType) {
+    return defaultAuthType;
+  }
   assertIsEndpointName(authenticationType);
   return authenticationType;
 }

--- a/src/params/auth/getCredentials.ts
+++ b/src/params/auth/getCredentials.ts
@@ -4,11 +4,12 @@
 import { URL } from 'url';
 import { ClientCredentials, UsernamePassword } from "@microsoft/powerplatform-cli-wrapper";
 import { getEndpointAuthorization, getEndpointUrl } from "azure-pipelines-task-lib";
-import getAuthenticationType from "./getAuthenticationType";
+import { getAuthenticationType, AuthenticationType } from "./getAuthenticationType";
 import { getEndpointName } from "./getEndpointName";
 
-export function getCredentials(): ClientCredentials | UsernamePassword {
-  const authenticationType = getAuthenticationType();
+
+export function getCredentials(defaultAuthType?: AuthenticationType): ClientCredentials | UsernamePassword {
+  const authenticationType = getAuthenticationType(defaultAuthType);
   switch (authenticationType) {
     case "PowerPlatformEnvironment":
       return getUsernamePassword();

--- a/src/params/auth/getEnvironmentUrl.ts
+++ b/src/params/auth/getEnvironmentUrl.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as tl from 'azure-pipelines-task-lib/task';
-import getAuthenticationType from './getAuthenticationType';
+import { AuthenticationType, getAuthenticationType } from './getAuthenticationType';
 import { getEndpointName } from './getEndpointName';
 import { EnvironmentParams, EnvUrlVariableName, GetPipelineOutputVariable, IsolateVariableReference } from '../../host/PipelineVariables';
 
@@ -59,8 +59,8 @@ export function getEnvironmentUrl(): string {
   return endpointUrl;
 }
 
-export function readEnvUrlFromServiceConnection(): string {
-  const authenticationType = getAuthenticationType();
+export function readEnvUrlFromServiceConnection(defaultAuthType?: AuthenticationType): string {
+  const authenticationType = getAuthenticationType(defaultAuthType);
   const endpointName = getEndpointName(authenticationType);
   if (!endpointName) {
     throw new Error(`Could not find endpoint: ${endpointName} for authentication type: ${authenticationType}`);

--- a/src/tasks/checker/checker-v0/index.ts
+++ b/src/tasks/checker/checker-v0/index.ts
@@ -8,10 +8,12 @@ import { isRunningOnAgent } from "../../../params/auth/isRunningOnAgent";
 import { BuildToolsHost } from "../../../host/BuildToolsHost";
 import { TaskParser } from "../../../parser/TaskParser";
 import { getCredentials } from "../../../params/auth/getCredentials";
+import { AuthenticationType } from '../../../params/auth/getAuthenticationType';
 import { AzurePipelineTaskDefiniton } from "../../../parser/AzurePipelineDefinitions";
-import * as taskDefinitionData from "./task.json";
 import { BuildToolsRunnerParams } from "../../../host/BuildToolsRunnerParams";
 import { readEnvUrlFromServiceConnection } from '../../../params/auth/getEnvironmentUrl';
+
+import * as taskDefinitionData from "./task.json";
 
 (async () => {
   if (isRunningOnAgent()) {
@@ -24,10 +26,12 @@ import { readEnvUrlFromServiceConnection } from '../../../params/auth/getEnviron
 export async function main(): Promise<void> {
   const taskParser = new TaskParser();
   const parameterMap = taskParser.getHostParameterEntries((taskDefinitionData as unknown) as AzurePipelineTaskDefiniton);
+  const defaultAuthType: AuthenticationType = 'PowerPlatformSPN';
 
   await checkSolution({
-    credentials: getCredentials(),
-    environmentUrl: readEnvUrlFromServiceConnection(),
+    // PS impl only supported single auth mode, SPN; some pipelines have no explicit value for authenticationType
+    credentials: getCredentials(defaultAuthType),
+    environmentUrl: readEnvUrlFromServiceConnection(defaultAuthType),
     fileLocation: parameterMap['FileLocation'],
     solutionPath: parameterMap['FilesToAnalyze'],
     solutionUrl: parameterMap['FilesToAnalyzeSasUri'],

--- a/test/componentTest.runtasks.ts
+++ b/test/componentTest.runtasks.ts
@@ -43,7 +43,7 @@ process.env['ENDPOINT_AUTH_CDS_ORG'] = `{ "parameters": { "username": "${usernam
 process.env['ENDPOINT_URL_CDS_ORG'] = envUrl;
 
 process.env['INPUT_PowerPlatformSpn'] = 'PP_SPN';
-process.env['ENDPOINT_AUTH_PP_SPN'] = `{ "Parameters": { "applicationId": "${appId}", "tenantId": "${tenantId}", "clientSecret": "${clientSecret}" } }`;
+process.env['ENDPOINT_AUTH_PP_SPN'] = `{ "parameters": { "applicationId": "${appId}", "tenantId": "${tenantId}", "clientSecret": "${clientSecret}" } }`;
 process.env['ENDPOINT_URL_PP_SPN'] = envUrl;
 
 //checker inputs


### PR DESCRIPTION
… specified in existing pipelines

cherry-pick of #112

[AB#2756028](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2756028)