### PR TITLE
fix fs.opendir() error: not available in node10

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -21,6 +21,9 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 
 # Release Notes
 {{NextReleaseVersion}}:
+- fix upload error for DeployPackage/Checker when running in release pipeline (#125)
+
+1.0.81:
 - Tasks are now implemented using [PowerPlatform CLI](https://aka.ms/PowerPlatformCLI)
 - Crossplatform support: Tasks can run on either Windows or Linux build agents
   (exception: 'Package Deploy' requires Windows)

--- a/src/host/BuildToolsHost.ts
+++ b/src/host/BuildToolsHost.ts
@@ -69,9 +69,9 @@ class AzDevOpsArtifactStore implements IArtifactStore {
       tl.uploadArtifact(this._subFolder, this._resultsDirectory, artifactName);
     } else {
       // pipeline has no artifact store (e.g. release pipelines):
-      const resultFiles = await fs.opendir(this._resultsDirectory);
+      const resultFiles = await fs.readdir(this._resultsDirectory);
       for await (const resultFile of resultFiles) {
-        const fqn = path.join(this._resultsDirectory, resultFile.name);
+        const fqn = path.join(this._resultsDirectory, resultFile);
         tl.uploadFile(fqn);
       }
     }


### PR DESCRIPTION
fs.opendir() cannot be used when running on AzDevOps agents, since those are still on node v10, see:
https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode10.md

#125
[AB#2776344](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2776344)
