### PR TITLE
[rel/stable] ImportSolution: deprecate PublishWorkflows in favor of ActivatePlugin

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -21,6 +21,9 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 
 # Release Notes
 {{NextReleaseVersion}}:
+- 'ActivatePlugins' task parameter is on by default; deprecate param 'PublishWorkflows' but consider both for plugin activation (#131)
+
+1.0.82:
 - fix upload error for DeployPackage/Checker when running in release pipeline (#125)
 
 1.0.81:

--- a/src/tasks/import-solution/import-solution-v0/task.json
+++ b/src/tasks/import-solution/import-solution-v0/task.json
@@ -104,7 +104,7 @@
       "visibleRule": "AsyncOperation = true",
       "required": true,
       "defaultValue": "60",
-      "helpMarkDown": "Maximum wait time in minutes for asynchronous Import; default is 60 min (1 hr), same as Azure DevOps default for tasks."
+      "helpMarkDown": "Maximum wait time in minutes for asynchronous Import; default is 60 min (1 hr), same as Azure DevOps default for tasks."
     },
     {
       "name": "HoldingSolution",
@@ -125,13 +125,13 @@
       "helpMarkDown": "Specify whether to overwrite unmanaged customizations."
     },
     {
-      "name": "PublishWorkflows",
-      "label": "Activate processes (workflows) after import",
+      "name": "ActivatePlugins",
+      "label": "Activate Plugins",
       "type": "boolean",
       "required": false,
       "defaultValue": true,
       "groupName": "advanced",
-      "helpMarkDown": "Specify whether any processes (workflows) in the solution should be activated after import."
+      "helpMarkDown": "Activate plug-ins and workflows on the solution."
     },
     {
       "name": "SkipProductUpdateDependencies",
@@ -152,13 +152,13 @@
       "helpMarkDown": "Specify whether to import as a Managed solution."
     },
     {
-      "name": "ActivatePlugins",
-      "label": "Activate Plugins",
+      "name": "PublishWorkflows",
+      "label": "(DEPRECATED, use 'Activate Plugins' instead) Activate processes (workflows) after import",
       "type": "boolean",
       "required": false,
       "defaultValue": false,
       "groupName": "advanced",
-      "helpMarkDown": "Activate plug-ins and workflows on the solution."
+      "helpMarkDown": "Specify whether any processes (workflows) in the solution should be activated after import."
     }
   ],
   "execution": {

--- a/test/actions/import-solution.test.ts
+++ b/test/actions/import-solution.test.ts
@@ -50,10 +50,10 @@ describe("import-solution tests", () => {
       maxAsyncWaitTimeInMin: { name: 'MaxAsyncWaitTime', required: true, defaultValue: '60' },
       importAsHolding: { name: 'HoldingSolution', required: false, defaultValue: false },
       forceOverwrite: { name: 'OverwriteUnmanagedCustomizations', required: false, defaultValue: false },
-      publishChanges: { name: 'PublishWorkflows', required: false, defaultValue: true },
+      publishChanges: { name: 'PublishWorkflows', required: false, defaultValue: false },
       skipDependencyCheck: { name: 'SkipProductUpdateDependencies', required: false, defaultValue: false },
       convertToManaged: { name: 'ConvertToManaged', required: false, defaultValue: false },
-      activatePlugins: { name: 'ActivatePlugins', required: false, defaultValue: false }
+      activatePlugins: { name: 'ActivatePlugins', required: false, defaultValue: true }
     }, new BuildToolsRunnerParams(), new BuildToolsHost());
   });
 });


### PR DESCRIPTION
The PS implementation exposed "PublishWorkflows" as the name in task.json, but under the covers assigned its value to the activatePlugins property in the ImportSolutionRequest to DV

We had introduced "ActivatePlugins" as new task property, which correctly reflects the actual semantics, but now caused a breaking change in behavior.

This PR now deprecates the outdated "PublishWorkflows" but now ensures that if either the old or new task property is set to true that plugins are indeed activated.

#131