### PR TITLE
[rel/stable] fix wrongly mapped --publish-changes CLI parameter

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -21,7 +21,10 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 
 # Release Notes
 {{NextReleaseVersion}}:
-- 'ActivatePlugins' task parameter is on by default; deprecate param 'PublishWorkflows' but consider both for plugin activation (#131)
+- 'Import Solution' task:
+  - 'ActivatePlugins' task parameter is on by default; deprecate param 'PublishWorkflows' but consider both for plugin activation (#131)
+  - fix forced 'PublishChanges' and its potential http timeout on PublishAllCustomizations (#129)
+  - introduces a new "PublishCustomizationChanges" task parameter to also publish customizations after successful import
 
 1.0.82:
 - fix upload error for DeployPackage/Checker when running in release pipeline (#125)

--- a/nuget.json
+++ b/nuget.json
@@ -15,12 +15,12 @@
       "packages": [
         {
           "name": "Microsoft.PowerApps.CLI",
-          "version": "1.15.9",
+          "version": "1.15.10",
           "internalName": "pac"
         },
         {
           "name": "Microsoft.PowerApps.CLI.Core.linux-x64",
-          "version": "1.15.9",
+          "version": "1.15.10",
           "internalName": "pac_linux",
           "chmod": "tools/pac"
         }

--- a/src/tasks/import-solution/import-solution-v0/index.ts
+++ b/src/tasks/import-solution/import-solution-v0/index.ts
@@ -38,7 +38,7 @@ export async function main(): Promise<void> {
     maxAsyncWaitTimeInMin: parameterMap['MaxAsyncWaitTime'],
     importAsHolding: parameterMap['HoldingSolution'],
     forceOverwrite: parameterMap['OverwriteUnmanagedCustomizations'],
-    publishChanges: parameterMap['PublishWorkflows'],
+    publishChanges: parameterMap['PublishCustomizationChanges'],
     skipDependencyCheck: parameterMap['SkipProductUpdateDependencies'],
     convertToManaged: parameterMap['ConvertToManaged'],
     // the fallback for default value 'true' corresponds with task.json's default value

--- a/src/tasks/import-solution/import-solution-v0/task.json
+++ b/src/tasks/import-solution/import-solution-v0/task.json
@@ -152,6 +152,15 @@
       "helpMarkDown": "Specify whether to import as a Managed solution."
     },
     {
+      "name": "PublishCustomizationChanges",
+      "label": "Publish customization changes",
+      "type": "boolean",
+      "required": false,
+      "defaultValue": false,
+      "groupName": "advanced",
+      "helpMarkDown": "Publish all customization changes after import succeeds; if set, this replaces the need for a separate 'Publish Customizations' task to follow the import task."
+    },
+    {
       "name": "PublishWorkflows",
       "label": "(DEPRECATED, use 'Activate Plugins' instead) Activate processes (workflows) after import",
       "type": "boolean",

--- a/test/actions/import-solution.test.ts
+++ b/test/actions/import-solution.test.ts
@@ -50,7 +50,7 @@ describe("import-solution tests", () => {
       maxAsyncWaitTimeInMin: { name: 'MaxAsyncWaitTime', required: true, defaultValue: '60' },
       importAsHolding: { name: 'HoldingSolution', required: false, defaultValue: false },
       forceOverwrite: { name: 'OverwriteUnmanagedCustomizations', required: false, defaultValue: false },
-      publishChanges: { name: 'PublishWorkflows', required: false, defaultValue: false },
+      publishChanges: { name: 'PublishCustomizationChanges', required: false, defaultValue: false },
       skipDependencyCheck: { name: 'SkipProductUpdateDependencies', required: false, defaultValue: false },
       convertToManaged: { name: 'ConvertToManaged', required: false, defaultValue: false },
       activatePlugins: { name: 'ActivatePlugins', required: false, defaultValue: true }


### PR DESCRIPTION
Fixes a bad mapping between task input parameters and pac CLI parameters
- This is now a new optional task input parameter "PublishCustomizationChanges"
- updated pac CLI to 1.15.10 to address the http timeout when the new task input is set

#129