### PR TITLE
[main] port hotfixes 132/137 and 134 from rel/stable

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -21,7 +21,10 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 
 # Release Notes
 {{NextReleaseVersion}}:
-- 'ActivatePlugins' task parameter is on by default; deprecate param 'PublishWorkflows' but consider both for plugin activation (#131)
+- 'Import Solution' task:
+  - 'ActivatePlugins' task parameter is on by default; deprecate param 'PublishWorkflows' but consider both for plugin activation (#131)
+  - fix forced 'PublishChanges' and its potential http timeout on PublishAllCustomizations (#129)
+  - introduces a new "PublishCustomizationChanges" task parameter to also publish customizations after successful import
 
 1.0.82:
 - fix upload error for DeployPackage/Checker when running in release pipeline (#125)

--- a/extension/overview.md
+++ b/extension/overview.md
@@ -21,6 +21,9 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 
 # Release Notes
 {{NextReleaseVersion}}:
+- 'ActivatePlugins' task parameter is on by default; deprecate param 'PublishWorkflows' but consider both for plugin activation (#131)
+
+1.0.82:
 - fix upload error for DeployPackage/Checker when running in release pipeline (#125)
 
 1.0.81:

--- a/src/tasks/import-solution/import-solution-v0/index.ts
+++ b/src/tasks/import-solution/import-solution-v0/index.ts
@@ -40,7 +40,7 @@ export async function main(): Promise<void> {
     maxAsyncWaitTimeInMin: parameterMap['MaxAsyncWaitTime'],
     importAsHolding: parameterMap['HoldingSolution'],
     forceOverwrite: parameterMap['OverwriteUnmanagedCustomizations'],
-    publishChanges: parameterMap['PublishWorkflows'],
+    publishChanges: parameterMap['PublishCustomizationChanges'],
     skipDependencyCheck: parameterMap['SkipProductUpdateDependencies'],
     convertToManaged: parameterMap['ConvertToManaged'],
     // WORKAROUND: current IHostAbstractions and its input processing in cli-wrapper will only look at the default value

--- a/src/tasks/import-solution/import-solution-v0/task.json
+++ b/src/tasks/import-solution/import-solution-v0/task.json
@@ -104,7 +104,7 @@
       "visibleRule": "AsyncOperation = true",
       "required": true,
       "defaultValue": "60",
-      "helpMarkDown": "Maximum wait time in minutes for asynchronous Import; default is 60 min (1 hr), same as Azure DevOps default for tasks."
+      "helpMarkDown": "Maximum wait time in minutes for asynchronous Import; default is 60 min (1 hr), same as Azure DevOps default for tasks."
     },
     {
       "name": "HoldingSolution",
@@ -125,13 +125,13 @@
       "helpMarkDown": "Specify whether to overwrite unmanaged customizations."
     },
     {
-      "name": "PublishWorkflows",
-      "label": "Activate processes (workflows) after import",
+      "name": "ActivatePlugins",
+      "label": "Activate Plugins",
       "type": "boolean",
       "required": false,
       "defaultValue": true,
       "groupName": "advanced",
-      "helpMarkDown": "Specify whether any processes (workflows) in the solution should be activated after import."
+      "helpMarkDown": "Activate plug-ins and workflows on the solution."
     },
     {
       "name": "SkipProductUpdateDependencies",
@@ -152,13 +152,13 @@
       "helpMarkDown": "Specify whether to import as a Managed solution."
     },
     {
-      "name": "ActivatePlugins",
-      "label": "Activate Plugins",
+      "name": "PublishWorkflows",
+      "label": "(DEPRECATED, use 'Activate Plugins' instead) Activate processes (workflows) after import",
       "type": "boolean",
       "required": false,
       "defaultValue": false,
       "groupName": "advanced",
-      "helpMarkDown": "Activate plug-ins and workflows on the solution."
+      "helpMarkDown": "Specify whether any processes (workflows) in the solution should be activated after import."
     }
   ],
   "execution": {

--- a/src/tasks/import-solution/import-solution-v0/task.json
+++ b/src/tasks/import-solution/import-solution-v0/task.json
@@ -152,6 +152,15 @@
       "helpMarkDown": "Specify whether to import as a Managed solution."
     },
     {
+      "name": "PublishCustomizationChanges",
+      "label": "Publish customization changes",
+      "type": "boolean",
+      "required": false,
+      "defaultValue": false,
+      "groupName": "advanced",
+      "helpMarkDown": "Publish all customization changes after import succeeds; if set, this replaces the need for a separate 'Publish Customizations' task to follow the import task."
+    },
+    {
       "name": "PublishWorkflows",
       "label": "(DEPRECATED, use 'Activate Plugins' instead) Activate processes (workflows) after import",
       "type": "boolean",

--- a/test/actions/import-solution.test.ts
+++ b/test/actions/import-solution.test.ts
@@ -50,7 +50,7 @@ describe("import-solution tests", () => {
       maxAsyncWaitTimeInMin: { name: 'MaxAsyncWaitTime', required: true, defaultValue: '60' },
       importAsHolding: { name: 'HoldingSolution', required: false, defaultValue: false },
       forceOverwrite: { name: 'OverwriteUnmanagedCustomizations', required: false, defaultValue: false },
-      publishChanges: { name: 'PublishWorkflows', required: false, defaultValue: false },
+      publishChanges: { name: 'PublishCustomizationChanges', required: false, defaultValue: false },
       skipDependencyCheck: { name: 'SkipProductUpdateDependencies', required: false, defaultValue: false },
       convertToManaged: { name: 'ConvertToManaged', required: false, defaultValue: false },
       activatePlugins: { name: 'MergedActivatePlugin', required: false, defaultValue: false }

--- a/test/actions/import-solution.test.ts
+++ b/test/actions/import-solution.test.ts
@@ -50,10 +50,10 @@ describe("import-solution tests", () => {
       maxAsyncWaitTimeInMin: { name: 'MaxAsyncWaitTime', required: true, defaultValue: '60' },
       importAsHolding: { name: 'HoldingSolution', required: false, defaultValue: false },
       forceOverwrite: { name: 'OverwriteUnmanagedCustomizations', required: false, defaultValue: false },
-      publishChanges: { name: 'PublishWorkflows', required: false, defaultValue: true },
+      publishChanges: { name: 'PublishWorkflows', required: false, defaultValue: false },
       skipDependencyCheck: { name: 'SkipProductUpdateDependencies', required: false, defaultValue: false },
       convertToManaged: { name: 'ConvertToManaged', required: false, defaultValue: false },
-      activatePlugins: { name: 'ActivatePlugins', required: false, defaultValue: false }
+      activatePlugins: { name: 'MergedActivatePlugin', required: false, defaultValue: false }
     }, new BuildToolsRunnerParams(), new BuildToolsHost());
   });
 });


### PR DESCRIPTION
- ImportSolution: deprecate PublishWorkflows in favor of ActivatePlugins
  cherry-pick of changes #132 and #137
  adresses #131

- fix wrongly mapped --publish-changes CLI parameter 
  cherry-pick of change #134
  adresses #129
  still requires the updated pac CLI changes in pac CLI that supports the async PublishCustomization 
 (https://dev.azure.com/msazure/One/_git/PowerPlatform-ISVEx-ToolsCore/pullrequest/6283824)
  in 1.16.x (work in progress)




