### PR TITLE
Revert "Allow user input of cloud type to reduce need to infer "

### DIFF
--- a/src/params/auth/getCredentials.ts
+++ b/src/params/auth/getCredentials.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { URL } from 'url';
 import { ClientCredentials, UsernamePassword } from "@microsoft/powerplatform-cli-wrapper";
 import { getEndpointAuthorization, getEndpointUrl } from "azure-pipelines-task-lib";
 import { getAuthenticationType, AuthenticationType } from "./getAuthenticationType";
 import { getEndpointName } from "./getEndpointName";
-import * as tl from 'azure-pipelines-task-lib/task';
+
 
 export function getCredentials(defaultAuthType?: AuthenticationType): ClientCredentials | UsernamePassword {
   const authenticationType = getAuthenticationType(defaultAuthType);
@@ -24,8 +25,8 @@ function getClientCredentials(): ClientCredentials {
     tenantId: params.tenantId,
     appId: params.applicationId,
     clientSecret: params.clientSecret,
-    cloudInstance: tl.getInput("Cloud", false) ?? resolveCloudInstance(endpointName)
-  }
+    cloudInstance: resolveCloudInstance(endpointName)
+  };
 }
 
 function getUsernamePassword(): UsernamePassword {
@@ -34,7 +35,7 @@ function getUsernamePassword(): UsernamePassword {
   return {
     username: params.username,
     password: params.password,
-    cloudInstance: tl.getInput("Cloud", false) ?? resolveCloudInstance(endpointName)
+    cloudInstance: resolveCloudInstance(endpointName)
   };
 }
 
@@ -48,22 +49,43 @@ function getEndpointAuthorizationParameters(
   return authorization.parameters;
 }
 
-/**
- * @note Required for backwards compatibility to the PS implementation:
- *       Infer the cloudInstance from the default endpoint url on the service connection
- *       see Get-Origin in https://dev.azure.com/dynamicscrm/OneCRM/_git/PowerApps.AzDevOpsExtensions?path=/src/extension/common/SharedFunctions.psm1&version=GBmaster&line=23&lineEnd=24&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
- */
+// needed for backwards compatibility to the PS implementation:
+// infer the cloudInstance from the default endpoint url on the service connection
+// see Get-Origin in https://dev.azure.com/dynamicscrm/OneCRM/_git/PowerApps.AzDevOpsExtensions?path=/src/extension/common/SharedFunctions.psm1&version=GBmaster&line=23&lineEnd=24&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
 function resolveCloudInstance(endpointName: string): string {
-  tl.debug(`Cloud not specified, falling back to inferring cloud instance using endpoint: ${endpointName}`);
   const defaultEndpointUrl = getEndpointUrl(endpointName, true);
   if (!defaultEndpointUrl) {
     return "Public";
   }
-  const regionalized = extractDomain(defaultEndpointUrl);
+  const hostname = new URL(defaultEndpointUrl)
+    .hostname
+    .split('.')
+    .reverse();
+  hostname.splice(-1);
+  const regionalized = hostname.reverse().join('.');
+
   // see also:
   // https://docs.microsoft.com/en-us/power-platform/admin/new-datacenter-regions
   // https://dev.azure.com/dynamicscrm/OneCRM/_git/CRM.DevToolsCore?path=%2Fsrc%2FGeneralTools%2FDataverseClient%2FClient%2FModel%2FDiscoveryServers.cs&_a=contents&version=GBmaster
   switch (regionalized) {
+    case 'crm.dynamics.com':
+    case 'crm2.dynamics.com':
+    case 'crm3.dynamics.com':
+    case 'crm4.dynamics.com':
+    case 'crm5.dynamics.com':
+    case 'crm6.dynamics.com':
+    case 'crm7.dynamics.com':
+    case 'crm8.dynamics.com':
+    case 'crm11.dynamics.com':
+    case 'crm12.dynamics.com':
+    case 'crm14.dynamics.com':
+    case 'crm15.dynamics.com':
+    case 'crm16.dynamics.com':
+    case 'crm17.dynamics.com':
+    case 'crm19.dynamics.com':
+    case 'crm20.dynamics.com':
+    case 'crm21.dynamics.com':
+      return "Public";
     case 'crm9.dynamics.com':
       return "UsGov";
     case 'crm.microsoftdynamics.us':
@@ -80,14 +102,3 @@ function resolveCloudInstance(endpointName: string): string {
       return "Public";
   }
 }
-
-function extractDomain(endpointUrl: string) {
-  const hostname = new URL(endpointUrl)
-    .hostname
-    .split('.')
-    .reverse();
-  hostname.splice(-1);
-  const regionalized = hostname.reverse().join('.');
-  return regionalized;
-}
-

--- a/src/tasks/add-solution-component/add-solution-component-v2/task.json
+++ b/src/tasks/add-solution-component/add-solution-component-v2/task.json
@@ -51,23 +51,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment",
       "type": "string",

--- a/src/tasks/assign-user/assign-user-v2/task.json
+++ b/src/tasks/assign-user/assign-user-v2/task.json
@@ -51,23 +51,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment",
       "type": "string",
@@ -89,6 +72,7 @@
       "required": true,
       "helpMarkDown": "Security role name or id to assign to the user"
     }
+
   ],
   "execution": {
     "Node10": {

--- a/src/tasks/copy-environment/copy-environment-v2/task.json
+++ b/src/tasks/copy-environment/copy-environment-v2/task.json
@@ -64,23 +64,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Source Environment Url",
       "type": "string",

--- a/src/tasks/create-environment/create-environment-v2/task.json
+++ b/src/tasks/create-environment/create-environment-v2/task.json
@@ -57,23 +57,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "DisplayName",
       "label": "Environment display name",
       "type": "string",

--- a/src/tasks/delete-environment/delete-environment-v2/task.json
+++ b/src/tasks/delete-environment/delete-environment-v2/task.json
@@ -51,23 +51,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment Url",
       "type": "string",

--- a/src/tasks/delete-solution/delete-solution-v2/task.json
+++ b/src/tasks/delete-solution/delete-solution-v2/task.json
@@ -51,23 +51,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment Url",
       "type": "string",

--- a/src/tasks/deploy-package/deploy-package-v2/task.json
+++ b/src/tasks/deploy-package/deploy-package-v2/task.json
@@ -51,23 +51,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment Url",
       "type": "string",

--- a/src/tasks/download-paportal/download-paportal-v2/task.json
+++ b/src/tasks/download-paportal/download-paportal-v2/task.json
@@ -50,23 +50,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment Url",
       "type": "string",

--- a/src/tasks/export-solution/export-solution-v2/task.json
+++ b/src/tasks/export-solution/export-solution-v2/task.json
@@ -58,23 +58,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment Url",
       "type": "string",

--- a/src/tasks/import-solution/import-solution-v2/task.json
+++ b/src/tasks/import-solution/import-solution-v2/task.json
@@ -58,23 +58,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment Url",
       "type": "string",

--- a/src/tasks/publish-customizations/publish-customizations-v2/task.json
+++ b/src/tasks/publish-customizations/publish-customizations-v2/task.json
@@ -51,23 +51,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment Url",
       "type": "string",

--- a/src/tasks/reset-environment/reset-environment-v2/task.json
+++ b/src/tasks/reset-environment/reset-environment-v2/task.json
@@ -64,23 +64,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment Url",
       "type": "string",

--- a/src/tasks/restore-environment/restore-environment-v2/task.json
+++ b/src/tasks/restore-environment/restore-environment-v2/task.json
@@ -64,23 +64,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment Url",
       "type": "string",

--- a/src/tasks/set-solution-version/set-solution-version-v2/task.json
+++ b/src/tasks/set-solution-version/set-solution-version-v2/task.json
@@ -51,23 +51,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "SolutionName",
       "label": "Solution Name",
       "type": "string",

--- a/src/tasks/whoami/whoami-v2/task.json
+++ b/src/tasks/whoami/whoami-v2/task.json
@@ -58,23 +58,6 @@
       "helpMarkDown": "Authenticate with your Power Platform environment with an Azure AppID, tenantID and client secret."
     },
     {
-      "name": "Cloud",
-      "label": "Cloud",
-      "type": "pickList",
-      "required": false,
-      "helpMarkDown": "Cloud instance to authenticate with. Please not, if not specified, the cloud instance will be inferred from the default environment URL within your tenant.",
-      "properties": {
-        "EditableOptions": "True"
-      },
-      "options": {
-        "Public": "Public",
-        "UsGov": "UsGov",
-        "UsGovHigh": "UsGovHigh",
-        "UsGovDod": "UsGovDod",
-        "Mooncake": "Mooncake"
-      }
-    },
-    {
       "name": "Environment",
       "label": "Environment Url",
       "type": "string",

--- a/test/commonTaskInputs.test.ts
+++ b/test/commonTaskInputs.test.ts
@@ -131,21 +131,5 @@ describe("getCredentials tests", () => {
       const result = getCredentials();
       result.cloudInstance.should.equal(variant.cloudInstance);
     });
-  }
-
-  it("Returns incorrect cloud when cloud instance is explicitly passed as user input.", () => {
-    const tipTest = { endpoint: 'https://aurora.crm10.dynamics.com', cloudInstance: 'Tip1' }
-    tlStub.getEndpointUrl
-    .withArgs(testEndpointName, true)
-    .returns(tipTest.endpoint);
-
-    const cloudInput = 'Mooncake';
-    tlStub.getInput
-    .withArgs("Cloud")
-    .returns(cloudInput);
-
-    const result = getCredentials();
-    result.cloudInstance.should.not.eq(tipTest.cloudInstance);
-    result.cloudInstance.should.equal(cloudInput);
-  });
+}
 });


### PR DESCRIPTION
Unfortunately, the new 'cloud' input property creates a conflict when the indicated region in the environmentUrl disagrees with what the user has selected in the 'cloud' input (either as default cloud value, or by mistake/oversight).

We'll bring this back in refined form later.

Reverting microsoft/powerplatform-build-tools#160