### PR TITLE
fix webpack running out of memory in official builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "node node_modules/gulp/bin/gulp.js compile",
     "test": "node node_modules/gulp/bin/gulp.js test",
     "ci": "node node_modules/gulp/bin/gulp.js ci --max_old_space_size=4096",
-    "prepare-pack": "node node_modules/gulp/bin/gulp.js preparePack",
+    "prepare-pack": "node node_modules/gulp/bin/gulp.js --max_old_space_size=4096 preparePack",
     "pack": "node node_modules/gulp/bin/gulp.js pack",
     "tfx": "node node_modules/tfx-cli/_build/tfx-cli.js",
     "set-git-authn": "node ./setGitAuthN.js",


### PR DESCRIPTION
official build pipeline calls a different npm script

applying same fix already used in #121