### PR TITLE
pac CLI 1.17.6 QFE for expiring auth token

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -22,6 +22,9 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 # Release Notes
 
 {{NextReleaseVersion}}:
+- pick up hot-fixed pac CLI 1.17.6 to address #179 and #180: accessToken expires after 60 min
+
+2.0.4:
 - pick up hot-fixed pac CLI 1.17.5 to address #171
 
 2.0.3:

--- a/nuget.json
+++ b/nuget.json
@@ -15,12 +15,12 @@
       "packages": [
         {
           "name": "Microsoft.PowerApps.CLI",
-          "version": "1.17.5",
+          "version": "1.17.6",
           "internalName": "pac"
         },
         {
           "name": "Microsoft.PowerApps.CLI.Core.linux-x64",
-          "version": "1.17.5",
+          "version": "1.17.6",
           "internalName": "pac_linux",
           "chmod": "tools/pac"
         }


### PR DESCRIPTION
addresses #179 and #180
[AB#2894540](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2894540)

this will also be cherry-picked to release/stable