### PR TITLE
mark export-data/import-data as windows only; add to func test suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.69",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.71",
         "azure-pipelines-task-lib": "^3.3.1",
         "debug": "^4.3.4",
         "fs-extra": "^10.0.1",
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.69",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.69/28d89aec59aef30d1e4bbbfe55ad44c38beb22e7",
-      "integrity": "sha512-OSJ/lQd3zT8DSfGCdWF5iEZdjIts1HyHUW8KbpyZnFbeySj2sta4nW9SC6kLLZhiE8w15jfoYZkNfogLnk10Cw==",
+      "version": "0.1.71",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.71/ed2d5cb1902195e2f5f4182c8bead60f8ccb4b98",
+      "integrity": "sha512-krJ8OMk494ZPHH7M4o82aj5U8mwdJwchGq7p26U2JsGoNEM/6H+NhlAlY2fvIxtSFFAURwNUT4+P4ENFIu5U1Q==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15607,9 +15607,9 @@
       }
     },
     "@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.69",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.69/28d89aec59aef30d1e4bbbfe55ad44c38beb22e7",
-      "integrity": "sha512-OSJ/lQd3zT8DSfGCdWF5iEZdjIts1HyHUW8KbpyZnFbeySj2sta4nW9SC6kLLZhiE8w15jfoYZkNfogLnk10Cw==",
+      "version": "0.1.71",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.71/ed2d5cb1902195e2f5f4182c8bead60f8ccb4b98",
+      "integrity": "sha512-krJ8OMk494ZPHH7M4o82aj5U8mwdJwchGq7p26U2JsGoNEM/6H+NhlAlY2fvIxtSFFAURwNUT4+P4ENFIu5U1Q==",
       "requires": {
         "fs-extra": "^10.0.1",
         "glob": "^8.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.72",
+        "@microsoft/powerplatform-cli-wrapper": "0.1.73",
         "azure-pipelines-task-lib": "^3.3.1",
         "debug": "^4.3.4",
         "fs-extra": "^10.0.1",
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.72",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.72/2ead041f770c2adca83349f9efee410691eb1e9f",
-      "integrity": "sha512-slKj9qpjZnnrGkiS4DBt676I6JRz9Ve+60ChSXQWYafbJlvsmMQbz/4lyNRL21DWbppbIQ8CL7EZgjQvnOr2jA==",
+      "version": "0.1.73",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.73/dd416ef0f86a6cd561f47d9cce5dc54047b4da06",
+      "integrity": "sha512-Xfal6hBXZcWUTiHVTmSuW1DOUMqWxcWyzvT/ubYw+Z+n1+Ys5etCWnjpM5jkBE7SmZNXWstOZhVqLkwtV4zwsA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15607,9 +15607,9 @@
       }
     },
     "@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.72",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.72/2ead041f770c2adca83349f9efee410691eb1e9f",
-      "integrity": "sha512-slKj9qpjZnnrGkiS4DBt676I6JRz9Ve+60ChSXQWYafbJlvsmMQbz/4lyNRL21DWbppbIQ8CL7EZgjQvnOr2jA==",
+      "version": "0.1.73",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.73/dd416ef0f86a6cd561f47d9cce5dc54047b4da06",
+      "integrity": "sha512-Xfal6hBXZcWUTiHVTmSuW1DOUMqWxcWyzvT/ubYw+Z+n1+Ys5etCWnjpM5jkBE7SmZNXWstOZhVqLkwtV4zwsA==",
       "requires": {
         "fs-extra": "^10.0.1",
         "glob": "^8.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.71",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.72",
         "azure-pipelines-task-lib": "^3.3.1",
         "debug": "^4.3.4",
         "fs-extra": "^10.0.1",
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.71",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.71/ed2d5cb1902195e2f5f4182c8bead60f8ccb4b98",
-      "integrity": "sha512-krJ8OMk494ZPHH7M4o82aj5U8mwdJwchGq7p26U2JsGoNEM/6H+NhlAlY2fvIxtSFFAURwNUT4+P4ENFIu5U1Q==",
+      "version": "0.1.72",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.72/2ead041f770c2adca83349f9efee410691eb1e9f",
+      "integrity": "sha512-slKj9qpjZnnrGkiS4DBt676I6JRz9Ve+60ChSXQWYafbJlvsmMQbz/4lyNRL21DWbppbIQ8CL7EZgjQvnOr2jA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15607,9 +15607,9 @@
       }
     },
     "@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.71",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.71/ed2d5cb1902195e2f5f4182c8bead60f8ccb4b98",
-      "integrity": "sha512-krJ8OMk494ZPHH7M4o82aj5U8mwdJwchGq7p26U2JsGoNEM/6H+NhlAlY2fvIxtSFFAURwNUT4+P4ENFIu5U1Q==",
+      "version": "0.1.72",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.72/2ead041f770c2adca83349f9efee410691eb1e9f",
+      "integrity": "sha512-slKj9qpjZnnrGkiS4DBt676I6JRz9Ve+60ChSXQWYafbJlvsmMQbz/4lyNRL21DWbppbIQ8CL7EZgjQvnOr2jA==",
       "requires": {
         "fs-extra": "^10.0.1",
         "glob": "^8.0.3"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "yargs": "^17.3.1"
   },
   "dependencies": {
-    "@microsoft/powerplatform-cli-wrapper": "^0.1.69",
+    "@microsoft/powerplatform-cli-wrapper": "^0.1.71",
     "azure-pipelines-task-lib": "^3.3.1",
     "debug": "^4.3.4",
     "fs-extra": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "yargs": "^17.3.1"
   },
   "dependencies": {
-    "@microsoft/powerplatform-cli-wrapper": "^0.1.72",
+    "@microsoft/powerplatform-cli-wrapper": "0.1.73",
     "azure-pipelines-task-lib": "^3.3.1",
     "debug": "^4.3.4",
     "fs-extra": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "yargs": "^17.3.1"
   },
   "dependencies": {
-    "@microsoft/powerplatform-cli-wrapper": "^0.1.71",
+    "@microsoft/powerplatform-cli-wrapper": "^0.1.72",
     "azure-pipelines-task-lib": "^3.3.1",
     "debug": "^4.3.4",
     "fs-extra": "^10.0.1",

--- a/src/tasks/deploy-package/deploy-package-v2/task.json
+++ b/src/tasks/deploy-package/deploy-package-v2/task.json
@@ -2,7 +2,7 @@
   "id": "c6ea89b6-4434-410c-b17f-c6c253175945",
   "name": "PowerPlatformDeployPackage",
   "friendlyName": "Power Platform Deploy Package",
-  "description": "Power Platform Deploy Package",
+  "description": "Power Platform Deploy Package. Requires Windows build agent",
   "author": "Microsoft",
   "helpMarkDown": "[More Info](https://aka.ms/buildtoolsdoc)",
   "category": "Deploy",

--- a/src/tasks/export-data/export-data-v2/index.ts
+++ b/src/tasks/export-data/export-data-v2/index.ts
@@ -5,6 +5,7 @@ import * as tl from 'azure-pipelines-task-lib/task';
 import { dataExport } from "@microsoft/powerplatform-cli-wrapper/dist/actions";
 import { BuildToolsRunnerParams } from "../../../host/BuildToolsRunnerParams";
 import { getCredentials } from "../../../params/auth/getCredentials";
+import { getEnvironmentUrl } from '../../../params/auth/getEnvironmentUrl';
 import { isRunningOnAgent } from '../../../params/auth/isRunningOnAgent';
 import * as taskDefinitionData from "./task.json";
 import { TaskParser } from "../../../parser/TaskParser";
@@ -26,6 +27,7 @@ export async function main(): Promise<void> {
 
   await dataExport({
     credentials: getCredentials(),
+    environmentUrl: getEnvironmentUrl(),
     schemaFile: parameterMap['SchemaFile'],
     dataFile: parameterMap['DataFile'],
     overwrite: parameterMap['Overwrite'],
@@ -34,6 +36,5 @@ export async function main(): Promise<void> {
       required: false,
       defaultValue: false
     },
-    environment: parameterMap['Environment'],
   }, new BuildToolsRunnerParams(), new BuildToolsHost());
 }

--- a/src/tasks/export-data/export-data-v2/task.json
+++ b/src/tasks/export-data/export-data-v2/task.json
@@ -2,7 +2,7 @@
   "id": "3137A4C5-0E44-4D89-AC0C-BEEDEC036428",
   "name": "PowerPlatformExportData",
   "friendlyName": "Power Platform Export Data",
-  "description": "Power Platform export data from environment with provided schema",
+  "description": "Power Platform export data from environment with provided schema. Requires Windows build agent",
   "author": "Microsoft",
   "helpMarkDown": "[More Info](https://aka.ms/buildtoolsdoc)",
   "category": "Deploy",

--- a/src/tasks/import-data/import-data-v2/index.ts
+++ b/src/tasks/import-data/import-data-v2/index.ts
@@ -28,7 +28,7 @@ export async function main(): Promise<void> {
   await dataImport({
     credentials: getCredentials(),
     environmentUrl: getEnvironmentUrl(),
-    dataDirectory: parameterMap['DataDirectory'],
+    dataFile: parameterMap['DataFile'],
     verbose: {
       name: "Verbose",
       required: false,

--- a/src/tasks/import-data/import-data-v2/index.ts
+++ b/src/tasks/import-data/import-data-v2/index.ts
@@ -5,6 +5,7 @@ import * as tl from 'azure-pipelines-task-lib/task';
 import { dataImport } from "@microsoft/powerplatform-cli-wrapper/dist/actions";
 import { BuildToolsRunnerParams } from "../../../host/BuildToolsRunnerParams";
 import { getCredentials } from "../../../params/auth/getCredentials";
+import { getEnvironmentUrl } from '../../../params/auth/getEnvironmentUrl';
 import { isRunningOnAgent } from '../../../params/auth/isRunningOnAgent';
 import * as taskDefinitionData from "./task.json";
 import { TaskParser } from "../../../parser/TaskParser";
@@ -26,12 +27,12 @@ export async function main(): Promise<void> {
 
   await dataImport({
     credentials: getCredentials(),
+    environmentUrl: getEnvironmentUrl(),
     dataDirectory: parameterMap['DataDirectory'],
     verbose: {
       name: "Verbose",
       required: false,
       defaultValue: false
     },
-    environment: parameterMap['Environment'],
   }, new BuildToolsRunnerParams(), new BuildToolsHost());
 }

--- a/src/tasks/import-data/import-data-v2/task.json
+++ b/src/tasks/import-data/import-data-v2/task.json
@@ -2,7 +2,7 @@
   "id": "3137A4C5-0E44-4D89-AC0C-BEEDEC036428",
   "name": "PowerPlatformImportData",
   "friendlyName": "Power Platform Import Data",
-  "description": "Power Platform import data to environment",
+  "description": "Power Platform import data to environment. Requires Windows build agent",
   "author": "Microsoft",
   "helpMarkDown": "[More Info](https://aka.ms/buildtoolsdoc)",
   "category": "Deploy",

--- a/src/tasks/import-data/import-data-v2/task.json
+++ b/src/tasks/import-data/import-data-v2/task.json
@@ -59,11 +59,11 @@
       "helpMarkDown": "Environment url this task targets; default is the pipeline variable that e.g. the CreateEnvironment task has set before."
     },
     {
-      "name": "DataDirectory",
-      "label": "Data Directory",
+      "name": "DataFile",
+      "label": "Data File",
       "type": "string",
       "required": true,
-      "helpMarkDown": "Directory name with data for import."
+      "helpMarkDown": "File name for data zip file to be imported."
     }
   ],
   "execution": {

--- a/test/Test-Data/dataSchema/EnvVarDefs.schema.xml
+++ b/test/Test-Data/dataSchema/EnvVarDefs.schema.xml
@@ -1,0 +1,15 @@
+<entities >
+  <entity name="environmentvariabledefinition" displayname="Environment Variable Definition" etc="380" primaryidfield="environmentvariabledefinitionid" primarynamefield="schemaname" disableplugins="false">
+    <fields>
+      <field displayname="Component State" name="componentstate" type="optionsetvalue" />
+      <field displayname="Environment Variable Definition" name="environmentvariabledefinitionid" type="guid" primaryKey="true" />
+      <field displayname="environmentvariabledefinitionidunique" name="environmentvariabledefinitionidunique" type="guid" />
+      <field displayname="Introduced Version" name="introducedversion" type="string" />
+      <field displayname="Is Managed" name="ismanaged" type="bool" />
+      <field displayname="Record Overwrite Time" name="overwritetime" type="datetime" />
+      <field displayname="Solution" name="solutionid" type="guid" />
+      <field displayname="Version Number" name="versionnumber" type="bigint" />
+    </fields>
+    <relationships />
+  </entity>
+</entities>

--- a/test/Test-Data/dataSchema/data.zip
+++ b/test/Test-Data/dataSchema/data.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77c82ed30dce82c19dcde45a7f62eaeef282b88a228387d03bdfef867fa5ac07
+size 1335

--- a/test/functional-test/functional-test-lib/taskTestRunner.ts
+++ b/test/functional-test/functional-test-lib/taskTestRunner.ts
@@ -13,6 +13,7 @@ export interface TaskInfo {
   name: string;
   path: string;
   inputVariables?: inputVariableDefinition[];
+  winOnly?: boolean;
 }
 
 export interface TaskResult {
@@ -46,7 +47,7 @@ export class TaskRunner {
     this.taskResult = cp.spawnSync('node', [normalizedTaskPath], { encoding: 'utf-8', cwd: this.taskDirectory });
     //console.debug(this.taskResult.stdout);
     this.validateTaskRun();
-    var envVar = this.setOutputEnvironmentVariables();
+    const envVar = this.setOutputEnvironmentVariables();
 
     logStdout(this.taskResult.stdout);
     debug(`Task: ${this.taskInfo.name} completed successfully.`);

--- a/test/functional-test/taskTestInput.ts
+++ b/test/functional-test/taskTestInput.ts
@@ -1,6 +1,7 @@
 import path = require("path");
 import os = require('os');
 import { TaskInfo } from "./functional-test-lib";
+import { ensureDirSync } from "fs-extra";
 
 export const deleteEnvironmentTaskName = 'delete-environment';
 export const createEnvironmentTaskName = 'create-environment';
@@ -17,6 +18,9 @@ const packedSolutionDirectory = path.join(solutionTestOutputRootDirectory, 'pack
 const schemaFile = path.join(testDataPath, 'dataSchema','EnvVarDefs.schema.xml');
 const dataZipFolder = path.join('out', 'data-test');
 const dataZip = path.join(dataZipFolder, 'data.zip');
+
+// AB#2919691 pac CLI stumbles if output folder doesn't exist:
+ensureDirSync(dataZipFolder);
 
 export const tasksToTest: TaskInfo[] =
   [
@@ -100,7 +104,7 @@ export const tasksToTest: TaskInfo[] =
       name: 'import-data',
       path: '/tasks/import-data/import-data-v2',
       inputVariables: [
-        { name: 'DataDirectory', value: dataZipFolder }
+        { name: 'DataFile', value: dataZip }
       ],
       winOnly: true
     },

--- a/test/functional-test/taskTestInput.ts
+++ b/test/functional-test/taskTestInput.ts
@@ -1,7 +1,7 @@
+import { ensureDirSync } from "fs-extra";
 import path = require("path");
 import os = require('os');
 import { TaskInfo } from "./functional-test-lib";
-import { ensureDirSync } from "fs-extra";
 
 export const deleteEnvironmentTaskName = 'delete-environment';
 export const createEnvironmentTaskName = 'create-environment';
@@ -16,7 +16,7 @@ const solutionTestOutputRootDirectory = path.join('out', 'solution-test');
 const unpackedSolutionDirectory = path.join(solutionTestOutputRootDirectory, 'unpacked-solution');
 const packedSolutionDirectory = path.join(solutionTestOutputRootDirectory, 'packed-solution');
 const schemaFile = path.join(testDataPath, 'dataSchema','EnvVarDefs.schema.xml');
-const dataZipFolder = path.join('out', 'data-test');
+const dataZipFolder = path.resolve('out', 'data-test');
 const dataZip = path.join(dataZipFolder, 'data.zip');
 
 // AB#2919691 pac CLI stumbles if output folder doesn't exist:
@@ -61,23 +61,23 @@ export const tasksToTest: TaskInfo[] =
         { name: 'ProcessCanvasApps', value: 'true' },
       ]
     },
-    // {
-    //   name: 'checker',
-    //   path: '/tasks/checker/checker-v2',
-    //   inputVariables: [
-    //     { name: 'FilesToAnalyze', value: path.join(testDataPath, 'componentsTestSolution_1_0_0_1.zip') },
-    //     { name: 'ArtifactDestinationName', value: 'PA-Checker-logs' },
-    //     { name: 'RuleSet', value: '0ad12346-e108-40b8-a956-9a8f95ea18c9' }
-    //   ]
-    // },
-    // {
-    //   name: 'deploy-package',
-    //   path: '/tasks/deploy-package/deploy-package-v2',
-    //   inputVariables: [
-    //     { name: 'PackageFile', value: path.join(testDataPath, 'testPkg', 'bin', 'Debug', 'testPkg.1.0.0.pdpkg.zip') }
-    //   ],
-    //   winOnly: true
-    // },
+    {
+      name: 'checker',
+      path: '/tasks/checker/checker-v2',
+      inputVariables: [
+        { name: 'FilesToAnalyze', value: path.join(testDataPath, 'componentsTestSolution_1_0_0_1.zip') },
+        { name: 'ArtifactDestinationName', value: 'PA-Checker-logs' },
+        { name: 'RuleSet', value: '0ad12346-e108-40b8-a956-9a8f95ea18c9' }
+      ]
+    },
+    {
+      name: 'deploy-package',
+      path: '/tasks/deploy-package/deploy-package-v2',
+      inputVariables: [
+        { name: 'PackageFile', value: path.join(testDataPath, 'testPkg', 'bin', 'Debug', 'testPkg.1.0.0.pdpkg.zip') }
+      ],
+      winOnly: true
+    },
     {
       name: 'import-solution',
       path: '/tasks/import-solution/import-solution-v2',
@@ -97,6 +97,7 @@ export const tasksToTest: TaskInfo[] =
       inputVariables: [
         { name: 'SchemaFile', value: schemaFile },
         { name: 'DataFile', value: dataZip },
+        { name: 'Overwrite', value: 'true' },
       ],
       winOnly: true
     },

--- a/test/functional-test/taskTestInput.ts
+++ b/test/functional-test/taskTestInput.ts
@@ -16,6 +16,7 @@ const unpackedSolutionDirectory = path.join(solutionTestOutputRootDirectory, 'un
 const packedSolutionDirectory = path.join(solutionTestOutputRootDirectory, 'packed-solution');
 const schemaFile = path.join(testDataPath, 'dataSchema','EnvVarDefs.schema.xml');
 const dataZipFolder = path.join('out', 'data-test');
+const dataZip = path.join(dataZipFolder, 'data.zip');
 
 export const tasksToTest: TaskInfo[] =
   [
@@ -56,23 +57,23 @@ export const tasksToTest: TaskInfo[] =
         { name: 'ProcessCanvasApps', value: 'true' },
       ]
     },
-    {
-      name: 'checker',
-      path: '/tasks/checker/checker-v2',
-      inputVariables: [
-        { name: 'FilesToAnalyze', value: path.join(testDataPath, 'componentsTestSolution_1_0_0_1.zip') },
-        { name: 'ArtifactDestinationName', value: 'PA-Checker-logs' },
-        { name: 'RuleSet', value: '0ad12346-e108-40b8-a956-9a8f95ea18c9' }
-      ]
-    },
-    {
-      name: 'deploy-package',
-      path: '/tasks/deploy-package/deploy-package-v2',
-      inputVariables: [
-        { name: 'PackageFile', value: path.join(testDataPath, 'testPkg', 'bin', 'Debug', 'testPkg.1.0.0.pdpkg.zip') }
-      ],
-      winOnly: true
-    },
+    // {
+    //   name: 'checker',
+    //   path: '/tasks/checker/checker-v2',
+    //   inputVariables: [
+    //     { name: 'FilesToAnalyze', value: path.join(testDataPath, 'componentsTestSolution_1_0_0_1.zip') },
+    //     { name: 'ArtifactDestinationName', value: 'PA-Checker-logs' },
+    //     { name: 'RuleSet', value: '0ad12346-e108-40b8-a956-9a8f95ea18c9' }
+    //   ]
+    // },
+    // {
+    //   name: 'deploy-package',
+    //   path: '/tasks/deploy-package/deploy-package-v2',
+    //   inputVariables: [
+    //     { name: 'PackageFile', value: path.join(testDataPath, 'testPkg', 'bin', 'Debug', 'testPkg.1.0.0.pdpkg.zip') }
+    //   ],
+    //   winOnly: true
+    // },
     {
       name: 'import-solution',
       path: '/tasks/import-solution/import-solution-v2',
@@ -90,8 +91,8 @@ export const tasksToTest: TaskInfo[] =
       name: 'export-data',
       path: '/tasks/export-data/export-data-v2',
       inputVariables: [
-        { name: 'SchemaFile', value: schemaFile},
-        { name: 'DataFile', value: 'data.zip'},
+        { name: 'SchemaFile', value: schemaFile },
+        { name: 'DataFile', value: dataZip },
       ],
       winOnly: true
     },

--- a/test/functional-test/taskTestInput.ts
+++ b/test/functional-test/taskTestInput.ts
@@ -11,9 +11,11 @@ const postfix = prNumber ? `PR${prNumber}` : os.hostname().split('.')[0].toLower
 const envFriendlyName = `ppbt-func-test-${process.platform == 'win32' ? 'win' : 'linux'}-${postfix}`;
 const testDataPath = path.resolve(__dirname, '..', 'Test-Data');
 const testableEmptySolutionPath = path.join(testDataPath, 'emptySolution_0_1_0_0.zip');
-const solutionTestOutputRootDirectory = 'out/solution-test';
-const unpackedSolutionDirectory = `${solutionTestOutputRootDirectory}/unpacked-solution`;
-const packedSolutionDirectory = `${solutionTestOutputRootDirectory}/packed-solution`;
+const solutionTestOutputRootDirectory = path.join('out', 'solution-test');
+const unpackedSolutionDirectory = path.join(solutionTestOutputRootDirectory, 'unpacked-solution');
+const packedSolutionDirectory = path.join(solutionTestOutputRootDirectory, 'packed-solution');
+const schemaFile = path.join(testDataPath, 'dataSchema','EnvVarDefs.schema.xml');
+const dataZipFolder = path.join('out', 'data-test');
 
 export const tasksToTest: TaskInfo[] =
   [
@@ -68,7 +70,8 @@ export const tasksToTest: TaskInfo[] =
       path: '/tasks/deploy-package/deploy-package-v2',
       inputVariables: [
         { name: 'PackageFile', value: path.join(testDataPath, 'testPkg', 'bin', 'Debug', 'testPkg.1.0.0.pdpkg.zip') }
-      ]
+      ],
+      winOnly: true
     },
     {
       name: 'import-solution',
@@ -82,6 +85,23 @@ export const tasksToTest: TaskInfo[] =
         { name: 'OverwriteUnmanagedCustomizations', value: 'false' },
         { name: 'HoldingSolution', value: 'false' },
       ]
+    },
+    {
+      name: 'export-data',
+      path: '/tasks/export-data/export-data-v2',
+      inputVariables: [
+        { name: 'SchemaFile', value: schemaFile},
+        { name: 'DataFile', value: 'data.zip'},
+      ],
+      winOnly: true
+    },
+    {
+      name: 'import-data',
+      path: '/tasks/import-data/import-data-v2',
+      inputVariables: [
+        { name: 'DataDirectory', value: dataZipFolder }
+      ],
+      winOnly: true
     },
     {
       name: 'set-solution-version',
@@ -126,5 +146,5 @@ export const tasksToTest: TaskInfo[] =
       return true;
     }
     // can't run on non-windows OS:
-    return task.name !== 'deploy-package';
+    return !task.winOnly
   });


### PR DESCRIPTION
- incorporate updated cli-wrapper .71 that detects and errors out if running on non-Windows agents
- update task description
- add data export/import to functional test

this PR is currently blocked on fixing a separate bug [AB#2916699](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/2916699) and should also NOT go in before the Aug refresh of pac CLI PR has merged #192 