### PR TITLE
Added support for Managed Identity

### DIFF
--- a/extension/service-connections.json
+++ b/extension/service-connections.json
@@ -56,7 +56,7 @@
           },
           {
             "type": "ms.vss-endpoint.endpoint-auth-scheme-managed-service-identity",
-            "displayName": "Managed Identity",
+            "displayName": "Azure Managed Identity",
             "inputDescriptors": [
               {
                 "id": "tenantid",

--- a/extension/service-connections.json
+++ b/extension/service-connections.json
@@ -14,12 +14,12 @@
         "authenticationSchemes": [
           {
             "type": "ms.vss-endpoint.endpoint-auth-scheme-none",
-            "displayName": "Power Platform authentication via Application ID and client secret",
+            "displayName": "Application Id and client secret",
             "inputDescriptors": [
               {
                 "id": "tenantId",
-                "name": "Tenant ID",
-                "description": "Tenant ID (also called directory ID in Azure portal) to authenticate to.\nRefer to <a href=\"https://aka.ms/buildtools-spn\" target=\"_blank\">https://aka.ms/buildtools-spn</a> for a script that shows Tenant ID and configures an Application ID and associated Client Secret. The application user must also be <a href=\"https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/use-single-tenant-server-server-authentication#application-user-creation\" target=\"_blank\">created in CDS</a> ",
+                "name": "Tenant Id",
+                "description": "Tenant Id (also called directory Id in Azure portal) to authenticate to.\nRefer to <a href=\"https://aka.ms/buildtools-spn\" target=\"_blank\">https://aka.ms/buildtools-spn</a> for a script that shows Tenant ID and configures an Application ID and associated Client Secret. The application user must also be <a href=\"https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/use-single-tenant-server-server-authentication#application-user-creation\" target=\"_blank\">created in CDS</a> ",
                 "inputMode": "textBox",
                 "isConfidential": false,
                 "groupName": "AuthenticationParameter",
@@ -30,8 +30,8 @@
               },
               {
                 "id": "applicationId",
-                "name": "Application ID",
-                "description": "Azure Application ID to authenticate with.",
+                "name": "Application Id",
+                "description": "Azure Application Id to authenticate with.",
                 "inputMode": "textBox",
                 "isConfidential": false,
                 "groupName": "AuthenticationParameter",
@@ -42,14 +42,35 @@
               },
               {
                 "id": "clientSecret",
-                "name": "Client secret of Application ID",
-                "description": "Client secret of the Service Principal associated to above Application ID; used to prove identity.",
+                "name": "Client secret of Application Id",
+                "description": "Client secret of the Service Principal associated to above Application Id; used to prove identity.",
                 "inputMode": "passwordBox",
                 "isConfidential": true,
                 "groupName": "AuthenticationParameter",
                 "validation": {
                   "dataType": "string",
                   "isRequired": true
+                }
+              }
+            ]
+          },
+          {
+            "type": "ms.vss-endpoint.endpoint-auth-scheme-managed-service-identity",
+            "displayName": "Managed Identity",
+            "inputDescriptors": [
+              {
+                "id": "tenantid",
+                "name": "Tenant Id",
+                "inputMode": "textBox",
+                "isConfidential": false,
+                "validation": {
+                  "dataType": "guid",
+                  "isRequired": false
+                },
+                "values": {
+                  "inputId": "tenantidInput",
+                  "defaultValue": "",
+                  "isDisabled": true
                 }
               }
             ]

--- a/src/params/auth/getCredentials.ts
+++ b/src/params/auth/getCredentials.ts
@@ -3,7 +3,7 @@
 
 import { URL } from 'url';
 import { ClientCredentials, UsernamePassword } from "@microsoft/powerplatform-cli-wrapper";
-import { getEndpointAuthorization, getEndpointUrl } from "azure-pipelines-task-lib";
+import { EndpointAuthorization, getEndpointAuthorization, getEndpointUrl } from "azure-pipelines-task-lib";
 import { getAuthenticationType, AuthenticationType } from "./getAuthenticationType";
 import { getEndpointName } from "./getEndpointName";
 
@@ -20,33 +20,34 @@ export function getCredentials(defaultAuthType?: AuthenticationType): ClientCred
 
 function getClientCredentials(): ClientCredentials {
   const endpointName = getEndpointName("PowerPlatformSPN");
-  const params = getEndpointAuthorizationParameters(endpointName);
+  const authorization = getEndpointAuthorizationParameters(endpointName);
   return {
-    tenantId: params.tenantId,
-    appId: params.applicationId,
-    clientSecret: params.clientSecret,
-    cloudInstance: resolveCloudInstance(endpointName)
+    tenantId: authorization.parameters.tenantId,
+    appId: authorization.parameters.applicationId,
+    clientSecret: authorization.parameters.clientSecret,
+    cloudInstance: resolveCloudInstance(endpointName),
+    scheme: authorization.scheme
   };
 }
 
 function getUsernamePassword(): UsernamePassword {
   const endpointName = getEndpointName("PowerPlatformEnvironment");
-  const params = getEndpointAuthorizationParameters(endpointName);
+  const authorization = getEndpointAuthorizationParameters(endpointName);
   return {
-    username: params.username,
-    password: params.password,
+    username: authorization.parameters.username,
+    password: authorization.parameters.password,
     cloudInstance: resolveCloudInstance(endpointName)
   };
 }
 
 function getEndpointAuthorizationParameters(
   endpointName: string
-): { [key: string]: string } {
+): EndpointAuthorization {
   const authorization = getEndpointAuthorization(endpointName, false);
   if (authorization === undefined) {
     throw new Error(`Could not get credentials for endpoint: ${endpointName}`);
   }
-  return authorization.parameters;
+  return authorization;
 }
 
 // needed for backwards compatibility to the PS implementation:


### PR DESCRIPTION
This PR adds support to pass Azure DevOps Build Agent [Managed Identity](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) through pac cli all the way to Dataverse Environment.

When creating new Power Platform Service Connection user will have a choice of two authentication methods: Application Id & Client Secret and Managed Identity. The new Managed Identity authentication method only needs target environment url.


![image](https://user-images.githubusercontent.com/30735471/206062581-bf48bee9-caed-4f3f-8a5c-cb5482655a54.png)

Useful links: 

- How to setup [Azure virtual machine scale set agents](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/scale-set-agents?view=azure-devops)

- How to configure [managed identities for Azure resources on a virtual machine scale set](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-portal-windows-vmss)