### PR TITLE
[rel/stable] fix for authN error when using MSI for linux agents

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -22,6 +22,9 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 # Release Notes
 
 {{NextReleaseVersion}}:
+- pac CLI 1.21.5 to fix Managed Identities authN on linux agents
+
+2.0.13:
 - added support for authentication via Azure Managed Identities
 
 2.0.10:

--- a/nuget.json
+++ b/nuget.json
@@ -15,12 +15,12 @@
       "packages": [
         {
           "name": "Microsoft.PowerApps.CLI",
-          "version": "1.21.4",
+          "version": "1.21.5",
           "internalName": "pac"
         },
         {
           "name": "Microsoft.PowerApps.CLI.Core.linux-x64",
-          "version": "1.21.4",
+          "version": "1.21.5",
           "internalName": "pac_linux",
           "chmod": "tools/pac"
         }


### PR DESCRIPTION
validated on a linux agent with a 2.0.14 EXP build from this branch:



![pp-bt-2 0 14EXP MSI fix](https://user-images.githubusercontent.com/3200210/208159887-06095ac4-dbe8-4df8-8ad2-389a095ac145.png)
