### PR TITLE
fix for authN error when using MSI for linux agents

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -22,8 +22,16 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 # Release Notes
 
 {{NextReleaseVersion}}:
+- pac CLI 1.21.5 to fix Managed Identities authN on linux agents
+
+2.0.13:
+- added support for authentication via Azure Managed Identities
+- pac CLI 1.21.x (November refresh)
+
+2.0.10:
 - new task 'Install Applications' to install D365 apps from AppSource
 - 'Deploy Package' has new optional parameter to pass in a package runtime settings json file
+- pac CLI 1.20.x (October refresh)
 
 2.0.8:
 - pac CLI 1.19.x (September refresh)

--- a/nuget.json
+++ b/nuget.json
@@ -15,12 +15,12 @@
       "packages": [
         {
           "name": "Microsoft.PowerApps.CLI",
-          "version": "1.20.3",
+          "version": "1.21.5",
           "internalName": "pac"
         },
         {
           "name": "Microsoft.PowerApps.CLI.Core.linux-x64",
-          "version": "1.20.3",
+          "version": "1.21.5",
           "internalName": "pac_linux",
           "chmod": "tools/pac"
         }


### PR DESCRIPTION
cherry-pick of #269 from rel/stable

* fix for authN error when using MSI for linux agents
* update rel notes

Co-authored-by: david@DAVID-PC <davidjen@microsoft.com>