### PR TITLE
CVE-2022-37614 Prototype pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/powerplatform-cli-wrapper": "^0.1.86",
-        "azure-pipelines-task-lib": "^3.4.0",
+        "azure-pipelines-task-lib": "^4.3.1",
         "debug": "^4.3.4",
         "fs-extra": "^10.0.1",
         "semver": "^7.3.5",
@@ -2085,9 +2085,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.4.0.tgz",
-      "integrity": "sha512-3eC4OTFw+7xD7A2aUhxR/j+jRlTI+vVfS0CGxt1pCLs4c/KmY0tQWgbqjD3157kmiucWxELBvgZHaD2gCBe9fg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.3.1.tgz",
+      "integrity": "sha512-AEwz0+Sofv80UviCYsS6fzyX5zzsLapmNCMNUoaRePZQVN+oQBStix1DGg4fdZf9zJ6acNd9xEBZQWbWuZu5Zg==",
       "inBundle": true,
       "dependencies": {
         "minimatch": "3.0.5",
@@ -17038,9 +17038,9 @@
       }
     },
     "azure-pipelines-task-lib": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.4.0.tgz",
-      "integrity": "sha512-3eC4OTFw+7xD7A2aUhxR/j+jRlTI+vVfS0CGxt1pCLs4c/KmY0tQWgbqjD3157kmiucWxELBvgZHaD2gCBe9fg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.3.1.tgz",
+      "integrity": "sha512-AEwz0+Sofv80UviCYsS6fzyX5zzsLapmNCMNUoaRePZQVN+oQBStix1DGg4fdZf9zJ6acNd9xEBZQWbWuZu5Zg==",
       "requires": {
         "minimatch": "3.0.5",
         "mockery": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@microsoft/powerplatform-cli-wrapper": "^0.1.86",
-    "azure-pipelines-task-lib": "^3.4.0",
+    "azure-pipelines-task-lib": "^4.3.1",
     "debug": "^4.3.4",
     "fs-extra": "^10.0.1",
     "semver": "^7.3.5",


### PR DESCRIPTION
Root dependency azure-pipelines-task-lib
Prototype pollution vulnerability in function enable in mockery.js in mfncooper mockery 