### PR TITLE
Use getEnvironmentUrl in Set Connection Variables task

### DIFF
--- a/src/tasks/set-connection-variables/set-connection-variables-v2/index.ts
+++ b/src/tasks/set-connection-variables/set-connection-variables-v2/index.ts
@@ -3,8 +3,8 @@
 
 import * as tl from 'azure-pipelines-task-lib/task';
 import { isRunningOnAgent } from "../../../params/auth/isRunningOnAgent";
+import { getEnvironmentUrl } from "../../../params/auth/getEnvironmentUrl";
 import {
-  EnvUrlVariableName,
   ApplicationIdlVariableName,
   ClientSecretVariableName,
   TenantIdVariableName,
@@ -23,7 +23,7 @@ import {
 
 export async function main(): Promise<void> {
   const authenticationType = tl.getInputRequired('authenticationType');
-  const endpointUrl = tl.getVariable(EnvUrlVariableName);
+  const environmentUrl = getEnvironmentUrl();
 
   switch (authenticationType) {
     case 'PowerPlatformSPN': {
@@ -36,7 +36,7 @@ export async function main(): Promise<void> {
       tl.setVariable(ClientSecretVariableName, clientSecret, true);
       tl.setVariable(TenantIdVariableName, tenantId, true);
 
-      const dataverseConnectionString = `AuthType=ClientSecret;url=${endpointUrl};ClientId=${applicationId};ClientSecret=${clientSecret}`;
+      const dataverseConnectionString = `AuthType=ClientSecret;url=${environmentUrl};ClientId=${applicationId};ClientSecret=${clientSecret}`;
       tl.setVariable(DataverseConnectionStringVariableName, dataverseConnectionString, true);
 
       break;
@@ -51,7 +51,7 @@ export async function main(): Promise<void> {
       const applicationId = tl.getInputRequired('ApplicationId');
       const redirectUri = tl.getInputRequired('RedirectUri');
 
-      const dataverseConnectionString = `AuthType=OAuth;url=${endpointUrl};UserName=${userName};Password=${password};AppId=${applicationId};RedirectUri=${redirectUri}`;
+      const dataverseConnectionString = `AuthType=OAuth;url=${environmentUrl};UserName=${userName};Password=${password};AppId=${applicationId};RedirectUri=${redirectUri}`;
       tl.setVariable(DataverseConnectionStringVariableName, dataverseConnectionString, true);
 
       break;

--- a/src/tasks/set-connection-variables/set-connection-variables-v2/task.json
+++ b/src/tasks/set-connection-variables/set-connection-variables-v2/task.json
@@ -80,7 +80,7 @@
       "name": "Environment",
       "label": "Environment Url",
       "type": "string",
-      "defaultValue": "$(BuildTools.EnvironmentUrl)",
+      "defaultValue": "",
       "required": false,
       "helpMarkDown": "Environment url this task targets; default is the pipeline variable that e.g. the CreateEnvironment task has set before."
     },

--- a/test/unit-test/set-connection-variables.test.ts
+++ b/test/unit-test/set-connection-variables.test.ts
@@ -6,7 +6,6 @@ import { should, use } from "chai";
 import * as sinonChai from "sinon-chai";
 import { restore } from "sinon";
 import {
-  EnvUrlVariableName,
   ApplicationIdlVariableName,
   ClientSecretVariableName,
   TenantIdVariableName,
@@ -14,6 +13,7 @@ import {
   UserNameVariableName,
   PasswordVariableName
 } from "../../src/host/PipelineVariables";
+import { mockEnvironmentUrl } from "./mockData";
 
 should();
 use(sinonChai);
@@ -41,6 +41,7 @@ describe('set-connection-variables tests', () => {
           getVariable: (name: string) => variables[name],
           getEndpointAuthorizationParameterRequired: (id: string, key: string) => authParams[key]
         });
+        mock(() => import("../../src/params/auth/getEnvironmentUrl")).with({ getEnvironmentUrl: () => mockEnvironmentUrl });
       }
     );
 
@@ -50,7 +51,6 @@ describe('set-connection-variables tests', () => {
   it('calls set-connection-variables with PowerPlatformSPN', async () => {
     inputs['authenticationType'] = 'PowerPlatformSPN';
     inputs['PowerPlatformSPN'] = 'mocked-svc-conn-id';
-    variables[EnvUrlVariableName] = 'https://mock-env-url';
 
     const mockedAppId = 'mocked-app-id';
     const mockedSecret = 'mocked-secret';
@@ -60,7 +60,7 @@ describe('set-connection-variables tests', () => {
     authParams['clientSecret'] = mockedSecret;
     authParams['tenantId'] = mockedTenantId;
 
-    const expectedDataverseConnectionString = `AuthType=ClientSecret;url=${variables[EnvUrlVariableName]};ClientId=${mockedAppId};ClientSecret=${mockedSecret}`;
+    const expectedDataverseConnectionString = `AuthType=ClientSecret;url=${mockEnvironmentUrl};ClientId=${mockedAppId};ClientSecret=${mockedSecret}`;
 
     await callActionWithMocks();
 
@@ -75,7 +75,6 @@ describe('set-connection-variables tests', () => {
     inputs['PowerPlatformEnvironment'] = 'mocked-svc-conn-id';
     inputs['ApplicationId'] = 'mocked-app-id';
     inputs['RedirectUri'] = 'mocked-redirect-uri';
-    variables[EnvUrlVariableName] = 'https://mock-env-url';
 
     const mockedUserNme = 'some@user.com';
     const mockedPassword = 'somePassord';
@@ -83,7 +82,7 @@ describe('set-connection-variables tests', () => {
     authParams['UserName'] = mockedUserNme;
     authParams['Password'] = mockedPassword;
 
-    const expectedDataverseConnectionString = `AuthType=OAuth;url=${variables[EnvUrlVariableName]};UserName=${mockedUserNme};Password=${mockedPassword};AppId=${inputs['ApplicationId']};RedirectUri=${inputs['RedirectUri']}`;
+    const expectedDataverseConnectionString = `AuthType=OAuth;url=${mockEnvironmentUrl};UserName=${mockedUserNme};Password=${mockedPassword};AppId=${inputs['ApplicationId']};RedirectUri=${inputs['RedirectUri']}`;
 
     await callActionWithMocks();
 


### PR DESCRIPTION
Hello Team, I ran into the issue described in #240 where the Connection String does not use the URL provided by the Service Connection. This behavior is not intuitive and does not match how other tasks work. 

The fix is really small. In stead of using the pipeline variable directly, use the `getEnvironmentUrl()` like all the other tasks do. This does not break current behavior. Since `getEnvironmentUrl()` also checks for the same pipeline variable, if it is set the variable will still take precedence over de URL from the Service Connection. 

I understand that currently the project is not officially open for Contributions. Mainly because the `@microsoft/powerplatform-cli-wrapper` is still internal to Microsoft. So I cannot build, run tests, or debug my proposed changes. Nonetheless, hopefully you do take this PR into consideration. Thanks!

