### PR TITLE
revert #318 - Remove Save Results Option

### DIFF
--- a/src/tasks/checker/checker-v2/index.ts
+++ b/src/tasks/checker/checker-v2/index.ts
@@ -46,7 +46,6 @@ export async function main(): Promise<void> {
     useDefaultPAEndpoint: parameterMap['UseDefaultPACheckerEndpoint'],
     customPAEndpoint: parameterMap['CustomPACheckerEndpoint'],
     geoInstance: { name: "GeoInstance", required: false, defaultValue: undefined },
-    saveResults: parameterMap['SaveResults'],
     logToConsole: isDiagnosticsMode ? true : false
   }, new BuildToolsRunnerParams(), new BuildToolsHost('PowerAppsChecker'));
 }

--- a/src/tasks/checker/checker-v2/index.ts
+++ b/src/tasks/checker/checker-v2/index.ts
@@ -46,6 +46,7 @@ export async function main(): Promise<void> {
     useDefaultPAEndpoint: parameterMap['UseDefaultPACheckerEndpoint'],
     customPAEndpoint: parameterMap['CustomPACheckerEndpoint'],
     geoInstance: { name: "GeoInstance", required: false, defaultValue: undefined },
+    saveResults: { name: "SaveResults", required: false, defaultValue: false },
     logToConsole: isDiagnosticsMode ? true : false
   }, new BuildToolsRunnerParams(), new BuildToolsHost('PowerAppsChecker'));
 }

--- a/src/tasks/checker/checker-v2/task.json
+++ b/src/tasks/checker/checker-v2/task.json
@@ -172,14 +172,6 @@
       "defaultValue": "CodeAnalysisLogs",
       "groupName": "advanced",
       "helpMarkDown": "Specify the Azure DevOps artifacts name for the Checker .sarif file."
-    },
-	{
-      "name": "SaveResults",
-      "label": "Save Results",
-      "type": "boolean",
-      "required": false,
-	    "defaultValue": false,
-      "helpMarkDown": "Uses current environment to store solution analysis results. By default, this argument is set to false"
     }
   ],
   "execution": {

--- a/test/unit-test/checker.test.ts
+++ b/test/unit-test/checker.test.ts
@@ -57,6 +57,7 @@ describe("check solution test", () => {
       useDefaultPAEndpoint: { name: 'UseDefaultPACheckerEndpoint', required: false, defaultValue: true },
       customPAEndpoint: { name: 'CustomPACheckerEndpoint', required: true, defaultValue: '' },
       geoInstance: { name: 'GeoInstance', required: false, defaultValue: undefined },
+      saveResults: { name: 'SaveResults', required: false, defaultValue: false },
       logToConsole: false
     }, new BuildToolsRunnerParams(), new BuildToolsHost('PowerAppsChecker'));
   });

--- a/test/unit-test/checker.test.ts
+++ b/test/unit-test/checker.test.ts
@@ -57,7 +57,6 @@ describe("check solution test", () => {
       useDefaultPAEndpoint: { name: 'UseDefaultPACheckerEndpoint', required: false, defaultValue: true },
       customPAEndpoint: { name: 'CustomPACheckerEndpoint', required: true, defaultValue: '' },
       geoInstance: { name: 'GeoInstance', required: false, defaultValue: undefined },
-      saveResults: { name: 'SaveResults', required: false, defaultValue: false },
       logToConsole: false
     }, new BuildToolsRunnerParams(), new BuildToolsHost('PowerAppsChecker'));
   });


### PR DESCRIPTION
revert #318 - Removing Pac Solution Check, Save Results Option, until the auth SPN policy is in place to handle calls to advisor/api/cdsanalysisrequest