### PR TITLE
Bump cli-wrapper version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.115",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "azure-pipelines-task-lib": "^4.4.0",
         "debug": "^4.3.4",
         "fs-extra": "^11.1.1",
@@ -578,9 +578,9 @@
       }
     },
     "node_modules/@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.115",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.115/2eac3ed16c843cec3eefbe4fbaf06843fc6ed03b",
-      "integrity": "sha512-ApTlsrhPzdAU3aLUFfW5PWE30dKZRho/v1jzF47s5CBBvJihZgilDjC+1W2ymuWOPAy5hP0luOFVtfYjVS9+5w==",
+      "version": "0.1.116",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.116/663e3d3f08f7cb084121bde94440aed9c11b2e2e",
+      "integrity": "sha512-9LI+meWFk12FnpZbRsd+9/4FU+ViAp+DM8G6aEpbJrb4X9zfG4JlTcBKOEsw1MK01s8PZ6rOaHnSw3AEsQdKSA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16671,9 +16671,9 @@
       }
     },
     "@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.115",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.115/2eac3ed16c843cec3eefbe4fbaf06843fc6ed03b",
-      "integrity": "sha512-ApTlsrhPzdAU3aLUFfW5PWE30dKZRho/v1jzF47s5CBBvJihZgilDjC+1W2ymuWOPAy5hP0luOFVtfYjVS9+5w==",
+      "version": "0.1.116",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.116/663e3d3f08f7cb084121bde94440aed9c11b2e2e",
+      "integrity": "sha512-9LI+meWFk12FnpZbRsd+9/4FU+ViAp+DM8G6aEpbJrb4X9zfG4JlTcBKOEsw1MK01s8PZ6rOaHnSw3AEsQdKSA==",
       "requires": {
         "fs-extra": "^11.1.1",
         "glob": "^10.3.3"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "@microsoft/powerplatform-cli-wrapper": "^0.1.115",
+    "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
     "azure-pipelines-task-lib": "^4.4.0",
     "debug": "^4.3.4",
     "fs-extra": "^11.1.1",


### PR DESCRIPTION
Bump cli-wrapper version to 0.1.116, as existing current version breaks Linux hosts in change introduced in 0.1.114