### PR TITLE
Revert "October Release (#590)" to test release failures

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -22,10 +22,6 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 # Release Notes
 
 {{NextReleaseVersion}}:
-- pac CLI 1.28.3 (September Refresh), [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI)
-- `Power Platform Import Solution` now supports `StageAndUpgrade` to import the solution as Holding and immediately queue as an Upgrade in a single command.  Previously, one would need to import as holding first, then run the `Power Platform Apply Solution Upgrade` as a second operation
-
-2.0.42:
 - pac CLI 1.27.6 (August Refresh), [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI)
 - `Power Platform Copy Environment` and `Power Platform Restore Environment` now support skipping audit data [#500](https://github.com/microsoft/powerplatform-build-tools/pull/500)
 - `Power Platform Copy Environment` and `Power Platform Restore Environment` can now override the default 60 minute async timeout [#521](https://github.com/microsoft/powerplatform-build-tools/pull/521)

--- a/nuget.json
+++ b/nuget.json
@@ -15,12 +15,12 @@
       "packages": [
         {
           "name": "Microsoft.PowerApps.CLI",
-          "version": "1.28.3",
+          "version": "1.27.6",
           "internalName": "pac"
         },
         {
           "name": "Microsoft.PowerApps.CLI.Core.linux-x64",
-          "version": "1.28.3",
+          "version": "1.27.6",
           "internalName": "pac_linux",
           "chmod": "tools/pac"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.118",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "azure-pipelines-task-lib": "^4.4.0",
         "debug": "^4.3.4",
         "fs-extra": "^11.1.1",
@@ -587,14 +587,14 @@
       }
     },
     "node_modules/@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.118",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.118/3b2c514efb9c0a9a13248da1e3b07dbbdb77edc1",
-      "integrity": "sha512-FV/uRS5/1nAENHvdlssT/SyQF8LzsVrjjXklbZla5L+fHEtFk0ObLW7SUcsYRSU/SY5lm+tzlEemq6cWBwStZA==",
+      "version": "0.1.116",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.116/663e3d3f08f7cb084121bde94440aed9c11b2e2e",
+      "integrity": "sha512-9LI+meWFk12FnpZbRsd+9/4FU+ViAp+DM8G6aEpbJrb4X9zfG4JlTcBKOEsw1MK01s8PZ6rOaHnSw3AEsQdKSA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
-        "glob": "^10.3.10"
+        "glob": "^10.3.3"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -6379,19 +6379,19 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+      "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
       "inBundle": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
+        "jackspeak": "^2.0.3",
         "minimatch": "^9.0.1",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
         "path-scurry": "^1.10.1"
       },
       "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "glob": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9077,9 +9077,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.2.tgz",
+      "integrity": "sha512-mgNtVv4vUuaKA97yxUHoA3+FkuhtxkjdXEWOyB/N76fjy0FjezEt34oy3epBtvCvS+7DyKwqCFWx/oJLV5+kCg==",
       "inBundle": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -16679,12 +16679,12 @@
       "dev": true
     },
     "@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.118",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.118/3b2c514efb9c0a9a13248da1e3b07dbbdb77edc1",
-      "integrity": "sha512-FV/uRS5/1nAENHvdlssT/SyQF8LzsVrjjXklbZla5L+fHEtFk0ObLW7SUcsYRSU/SY5lm+tzlEemq6cWBwStZA==",
+      "version": "0.1.116",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.116/663e3d3f08f7cb084121bde94440aed9c11b2e2e",
+      "integrity": "sha512-9LI+meWFk12FnpZbRsd+9/4FU+ViAp+DM8G6aEpbJrb4X9zfG4JlTcBKOEsw1MK01s8PZ6rOaHnSw3AEsQdKSA==",
       "requires": {
         "fs-extra": "^11.1.1",
-        "glob": "^10.3.10"
+        "glob": "^10.3.3"
       }
     },
     "@nodelib/fs.scandir": {
@@ -21140,12 +21140,12 @@
       }
     },
     "glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+      "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
       "requires": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
+        "jackspeak": "^2.0.3",
         "minimatch": "^9.0.1",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
         "path-scurry": "^1.10.1"
@@ -23129,9 +23129,9 @@
       }
     },
     "jackspeak": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.2.tgz",
+      "integrity": "sha512-mgNtVv4vUuaKA97yxUHoA3+FkuhtxkjdXEWOyB/N76fjy0FjezEt34oy3epBtvCvS+7DyKwqCFWx/oJLV5+kCg==",
       "requires": {
         "@isaacs/cliui": "^8.0.2",
         "@pkgjs/parseargs": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "@microsoft/powerplatform-cli-wrapper": "^0.1.118",
+    "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
     "azure-pipelines-task-lib": "^4.4.0",
     "debug": "^4.3.4",
     "fs-extra": "^11.1.1",

--- a/src/tasks/import-solution/import-solution-v2/index.ts
+++ b/src/tasks/import-solution/import-solution-v2/index.ts
@@ -41,7 +41,6 @@ export async function main(): Promise<void> {
     async: parameterMap['AsyncOperation'],
     maxAsyncWaitTimeInMin: parameterMap['MaxAsyncWaitTime'],
     importAsHolding: parameterMap['HoldingSolution'],
-    stageAndUpgrade: parameterMap['StageAndUpgrade'],
     forceOverwrite: parameterMap['OverwriteUnmanagedCustomizations'],
     publishChanges: parameterMap['PublishCustomizationChanges'],
     skipDependencyCheck: parameterMap['SkipProductUpdateDependencies'],

--- a/src/tasks/import-solution/import-solution-v2/task.json
+++ b/src/tasks/import-solution/import-solution-v2/task.json
@@ -116,15 +116,6 @@
       "helpMarkDown": "Specify whether to import as a holding solution to stage for an upgrade."
     },
     {
-      "name": "StageAndUpgrade",
-      "label": "Import the managed solution and immediately apply it as an upgrade.",
-      "type": "boolean",
-      "required": false,
-      "defaultValue": false,
-      "groupName": "advanced",
-      "helpMarkDown": "Specify whether to import the managed solution and apply as an upgrade."
-    },
-    {
       "name": "OverwriteUnmanagedCustomizations",
       "label": "Overwrite unmanaged customizations",
       "type": "boolean",

--- a/test/unit-test/import-solution.test.ts
+++ b/test/unit-test/import-solution.test.ts
@@ -49,7 +49,6 @@ describe("import-solution tests", () => {
       async: { name: 'AsyncOperation', required: true, defaultValue: true },
       maxAsyncWaitTimeInMin: { name: 'MaxAsyncWaitTime', required: true, defaultValue: '60' },
       importAsHolding: { name: 'HoldingSolution', required: false, defaultValue: false },
-      stageAndUpgrade: { name: 'StageAndUpgrade', required: false, defaultValue: false },
       forceOverwrite: { name: 'OverwriteUnmanagedCustomizations', required: false, defaultValue: false },
       publishChanges: { name: 'PublishCustomizationChanges', required: false, defaultValue: false },
       skipDependencyCheck: { name: 'SkipProductUpdateDependencies', required: false, defaultValue: false },


### PR DESCRIPTION
This reverts commit 00e7cdee885e5bb85e3c9c5b9dba3d2bcc552fc4.

Reverting the last change to test the release pipeline to determine if previous changes (only dependabot updates) or if the CLI Wrapper / PAC update is causing the release failure.