### PR TITLE
Update PAC only, no cli-wrapper

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -22,6 +22,9 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 # Release Notes
 
 {{NextReleaseVersion}}:
+- pac CLI 1.28.3 (September Refresh), [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI)
+
+2.0.42:
 - pac CLI 1.27.6 (August Refresh), [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI)
 - `Power Platform Copy Environment` and `Power Platform Restore Environment` now support skipping audit data [#500](https://github.com/microsoft/powerplatform-build-tools/pull/500)
 - `Power Platform Copy Environment` and `Power Platform Restore Environment` can now override the default 60 minute async timeout [#521](https://github.com/microsoft/powerplatform-build-tools/pull/521)

--- a/nuget.json
+++ b/nuget.json
@@ -15,12 +15,12 @@
       "packages": [
         {
           "name": "Microsoft.PowerApps.CLI",
-          "version": "1.27.6",
+          "version": "1.28.3",
           "internalName": "pac"
         },
         {
           "name": "Microsoft.PowerApps.CLI.Core.linux-x64",
-          "version": "1.27.6",
+          "version": "1.28.3",
           "internalName": "pac_linux",
           "chmod": "tools/pac"
         }


### PR DESCRIPTION
Testing the break in the release pipeline
Only update PAC itself, not the cli-wrapper, to narrow down the break to being just PAC, or if the issue comes from cli-wrapper changes