### PR TITLE
Fix auth flow detection of `--cloud` argument to rename 'Mooncake' to 'China'

### DIFF
--- a/src/params/auth/getCredentials.ts
+++ b/src/params/auth/getCredentials.ts
@@ -96,7 +96,7 @@ function resolveCloudInstance(endpointName: string): string {
     case 'crm.appsplatform.us':
       return "UsGovDod";
     case 'crm.dynamics.cn':
-      return "Mooncake";
+      return "China";
     case 'crm10.dynamics.com':
       return "Preprod";
     case 'crmtest.dynamics.com':

--- a/test/commonTaskInputs.test.ts
+++ b/test/commonTaskInputs.test.ts
@@ -118,7 +118,7 @@ describe("getCredentials tests", () => {
     { endpoint: 'https://ppdevtools.crm.dynamics.com', cloudInstance: 'Public' },
     { endpoint: 'https://aurora.crm10.dynamics.com', cloudInstance: 'Tip1' },
     { endpoint: 'https://kc.crm9.dynamics.com', cloudInstance: 'UsGov' },
-    { endpoint: 'https://niehau.crm.dynamics.cn', cloudInstance: 'Mooncake' },
+    { endpoint: 'https://niehau.crm.dynamics.cn', cloudInstance: 'China' },
     { endpoint: undefined, cloudInstance: 'Public' },
     { endpoint: 'http://bing.com', cloudInstance: 'Public' },
   ];


### PR DESCRIPTION
This was a breaking change in the Pac CLI which was missed.

A follow-up PR should remove all this logic for detecting the cloud all together, as this logic has been moved into the implementation of `pac auth create`