### PR TITLE
Prepend pacPath to the PATH environment variable

### DIFF
--- a/src/host/CliLocator.ts
+++ b/src/host/CliLocator.ts
@@ -4,6 +4,11 @@ import path = require('path');
 import { pathExists, chmod } from 'fs-extra';
 
 export async function findPacCLI(): Promise<string> {
+  // cli-wrapper expects the root folder, see: src\pac\createPacRunner.ts
+  return (await findPacCLIPath()).pacRootPath;
+}
+
+export async function findPacCLIPath(): Promise<{ pacRootPath: string, pacPath: string }> {
   const pacRootPath = path.resolve(__dirname, 'bin');
   let pacPath: string;
   switch (process.platform) {
@@ -20,6 +25,9 @@ export async function findPacCLI(): Promise<string> {
   if (!await pathExists(pacPath)) {
     throw new Error(`Cannot find required pac CLI executable under: ${pacPath}`);
   }
-  // cli-wrapper expects the root folder, see: src\pac\createPacRunner.ts
-  return pacRootPath;
+
+  const lastSlashIndex = pacPath.lastIndexOf("/");
+  pacPath = pacPath.substring(0, lastSlashIndex);
+
+  return { pacRootPath, pacPath};
 }

--- a/src/tasks/tool-installer/tool-installer-v2/index.ts
+++ b/src/tasks/tool-installer/tool-installer-v2/index.ts
@@ -18,6 +18,7 @@ export async function main(): Promise<void> {
 
   tl.debug(`Found required pac CLI executable under: ${pacPath}`);
   tl.debug(`Setting ${PacPathEnvVarName} : ${pacPath}`);
+  tl.prependPath(pacPath);
   tl.setVariable(PacPathEnvVarName, pacPath);
 }
 

--- a/src/tasks/tool-installer/tool-installer-v2/index.ts
+++ b/src/tasks/tool-installer/tool-installer-v2/index.ts
@@ -2,23 +2,26 @@
 // Licensed under the MIT License.
 
 import * as tl from 'azure-pipelines-task-lib/task';
-import { findPacCLI } from '../../../host/CliLocator';
+import { findPacCLIPath } from '../../../host/CliLocator';
 import { PacPathEnvVarName } from '../../../host/BuildToolsRunnerParams';
 
 (async () => {
   if (process.env['AGENT_JOBNAME']) {
-      await main();
+    await main();
   }
 })().catch(error => {
   tl.setResult(tl.TaskResult.Failed, error);
 });
 
 export async function main(): Promise<void> {
-  const pacPath = await findPacCLI();
+  const addToolsToPath = tl.getInputRequired('AddToolsToPath').toLowerCase() === 'true';
+  const { pacRootPath, pacPath } = await findPacCLIPath();
 
-  tl.debug(`Found required pac CLI executable under: ${pacPath}`);
-  tl.debug(`Setting ${PacPathEnvVarName} : ${pacPath}`);
-  tl.prependPath(pacPath);
-  tl.setVariable(PacPathEnvVarName, pacPath);
+  tl.debug(`Found required pac CLI executable under: ${pacRootPath}`);
+  tl.debug(`Setting ${PacPathEnvVarName} : ${pacRootPath}`);
+  if (addToolsToPath) {
+    tl.prependPath(pacPath);
+  }
+  tl.setVariable(PacPathEnvVarName, pacRootPath);
 }
 

--- a/src/tasks/tool-installer/tool-installer-v2/task.json
+++ b/src/tasks/tool-installer/tool-installer-v2/task.json
@@ -29,7 +29,15 @@
       "type": "boolean",
       "required": true,
       "helpMarkDown": "OBSOLETE: Current task implementations are no longer based on Powershell modules. This ToolInstaller task always installs the latest pac CLI (Power Platform CLI) that is available for this task extension. The additional task parameters are kept to avoid breaking changes with existing Azure DevOps pipelines.",
-      "defaultValue":true
+      "defaultValue": true
+    },
+    {
+      "name": "AddToolsToPath",
+      "label": "Adds the pac cli to the PATH environment variable",
+      "type": "boolean",
+      "required": false,
+      "helpMarkDown": "Enables you to use pac cli from script tasks without needing to set up the path manually.",
+      "defaultValue": false
     },
     {
       "name": "PowerAppsAdminVersion",
@@ -38,7 +46,7 @@
       "required": false,
       "helpMarkDown": "IGNORED: This version of the BuildTools no longer depends on any PowerShell modules; specifying any version value will be ignored",
       "defaultValue": "(obsolete)",
-      "groupname":"advanced"
+      "groupname": "advanced"
     },
     {
       "name": "XrmToolingPackageDeploymentVersion",
@@ -47,7 +55,7 @@
       "required": false,
       "helpMarkDown": "IGNORED: This version of the BuildTools no longer depends on any PowerShell modules; specifying any version value will be ignored",
       "defaultValue": "(obsolete)",
-      "groupname":"advanced"
+      "groupname": "advanced"
     },
     {
       "name": "MicrosoftPowerAppsCheckerVersion",
@@ -56,7 +64,7 @@
       "required": true,
       "helpMarkDown": "IGNORED: This version of the BuildTools no longer depends on any PowerShell modules; specifying any version value will be ignored",
       "defaultValue": "(obsolete)",
-      "groupname":"advanced"
+      "groupname": "advanced"
     },
     {
       "name": "CrmSdkCoreToolsVersion",
@@ -65,7 +73,7 @@
       "required": false,
       "helpMarkDown": "IGNORED: This version of the BuildTools no longer depends on any PowerShell modules; specifying any version value will be ignored",
       "defaultValue": "(obsolete)",
-      "groupname":"advanced"
+      "groupname": "advanced"
     },
     {
       "name": "XrmOnlineManagementApiVersion",
@@ -74,15 +82,15 @@
       "required": false,
       "helpMarkDown": "IGNORED: This version of the BuildTools no longer depends on any PowerShell modules; specifying any version value will be ignored",
       "defaultValue": "(obsolete)",
-      "groupname":"advanced"
+      "groupname": "advanced"
     }
   ],
   "groups": [
     {
-        "name": "advanced",
-        "displayName": "Advanced",
-        "isExpanded": false,
-        "visibleRule": "DefaultVersion = false"
+      "name": "advanced",
+      "displayName": "Advanced",
+      "isExpanded": false,
+      "visibleRule": "DefaultVersion = false"
     }
   ],
   "execution": {

--- a/test/unit-test/tool-installer.test.ts
+++ b/test/unit-test/tool-installer.test.ts
@@ -1,23 +1,56 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { should, use } from "chai";
+import { assert, should, use } from "chai";
 import * as sinonChai from "sinon-chai";
 import rewiremock from "../rewiremock";
+import { debug } from "console";
+import { restore } from "sinon";
 should();
 use(sinonChai);
 
 describe("tool-installer tests", () => {
+  const cliLocatorPath = "path/from/mocked/cli/locator";
+  const cliExecutablePath = `${cliLocatorPath}/pac/tools`;
+  const addToolsToPath = 'AddToolsToPath';
+  let prependPathValue: string;
+  let inputs: { [key: string]: string };
+  let variables: { [key: string]: string };
+
+  beforeEach(() => {
+    prependPathValue = '';
+    inputs = {};
+    variables = {};
+  });
+  afterEach(() => restore());
+
   async function callActionWithMocks(): Promise<void> {
     const toolInstaller = await rewiremock.around(
       () => import("../../src/tasks/tool-installer/tool-installer-v2/index"),
-      (mock : any) => {
-        mock(() => import("../../src/host/CliLocator")).with({ findPacCLI: () => Promise.resolve("path/from/mocked/cli/locator") });
+      (mock: any) => {
+        mock(() => import("azure-pipelines-task-lib")).with({
+          getInputRequired: (name: string) => inputs[name],
+          setVariable: (name: string, val: string, secret?: boolean | undefined, isOutput?: boolean | undefined): void => {
+            variables[name] = val;
+          },
+          debug: (message: string) => debug(message),
+          prependPath: (path: string) => prependPathValue = path
+        });
+        mock(() => import("../../src/host/CliLocator")).with({
+          findPacCLIPath: () => Promise.resolve({ pacRootPath: cliLocatorPath, pacPath: cliExecutablePath })
+        });
       });
     await toolInstaller.main();
   }
 
-  it("call task", async () => {
+  it("calls tool-installer", async () => {
+    inputs[addToolsToPath] = 'false';
     await callActionWithMocks();
+  });
+
+  it("call tool-installer with AddToolsToPath=true and calls prependPath.", async () => {
+    inputs[addToolsToPath] = 'true';
+    await callActionWithMocks();
+    assert.equal(prependPathValue, cliExecutablePath);
   });
 });


### PR DESCRIPTION
Enables making pac callable from script tasks without any need to manually set up the path or  lookup POWERPLATFORMTOOLS_PACCLIPATH