### PR TITLE
Remove deprecated @types/node version and add override for compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "@types/debug": "^4.1.12",
         "@types/fs-extra": "^11.0.4",
         "@types/mocha": "^10.0.6",
-        "@types/node": "^20.12.11",
         "@types/q": "^1.5.8",
         "@types/semver": "^7.5.8",
         "@types/sinon": "^10.0.16",
@@ -7616,13 +7615,6 @@
         "@types/node": "^10.0.3"
       }
     },
-    "node_modules/http-response-object/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
@@ -13341,13 +13333,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/then-request/node_modules/@types/node": {
-      "version": "8.10.66",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/through2": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
@@ -13699,13 +13684,6 @@
         "lodash.get": "^4.4.2",
         "type-detect": "^4.0.8"
       }
-    },
-    "node_modules/ts-sinon/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ts-sinon/node_modules/@types/sinon": {
       "version": "9.0.11",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@types/debug": "^4.1.12",
     "@types/fs-extra": "^11.0.4",
     "@types/mocha": "^10.0.6",
-    "@types/node": "^20.12.11",
     "@types/q": "^1.5.8",
     "@types/semver": "^7.5.8",
     "@types/sinon": "^10.0.16",
@@ -74,6 +73,9 @@
     "webpack-cli": "^5.1.4",
     "webpack-node-externals": "^3.0.0",
     "yargs": "^17.7.2"
+  },
+  "overrides": {
+      "@types/node": "~20.19.0"
   },
   "dependencies": {
     "@microsoft/powerplatform-cli-wrapper": "^0.1.135",


### PR DESCRIPTION
This pull request updates the `package.json` file to address type dependency management for `@types/node` by replacing the direct dependency with an override. This ensures compatibility with specific versions of the Node.js type definitions.

Dependency management changes:

* Removed the direct dependency on `@types/node` (`^20.12.11`) from the `devDependencies` section.
* Added an `overrides` section to specify `@types/node` version `~20.19.0`, ensuring a controlled version is used across the project.