### PR TITLE
fix: exclude nested _rels/.rels from VSIX bin for ESRP signing (ICM 779156496)

### DIFF
--- a/gulp/pack.mjs
+++ b/gulp/pack.mjs
@@ -145,8 +145,22 @@ async function copyDependencies() {
   const binFolder = path.resolve("bin");
   const toolInstallerFolder = `${stagingDir}/tasks/tool-installer/tool-installer-v2`;
 
+  // Exclude the two nested _rels/.rels files that cause ESRP vsixsigntool.exe to fail
+  // with error 0x80510005. These are OPC metadata artifacts left behind when the pac CLI
+  // NuGet packages are extracted — they reference non-existent targets and confuse the
+  // OPC parser inside vsixsigntool.exe when it encounters them inside a VSIX (itself OPC).
+  // See: ICM 779156496
+  const EXCLUDED_BIN_FILES = new Set([
+    path.join("pac", "_rels", ".rels"),
+    path.join("pac_linux", "_rels", ".rels"),
+  ]);
+  const binFileFilter = (src) => {
+    const rel = path.relative(binFolder, src);
+    return !EXCLUDED_BIN_FILES.has(rel);
+  };
+
   await Promise.all([
-    fs.copy(binFolder, `${toolInstallerFolder}/bin`, { recursive: true }),
+    fs.copy(binFolder, `${toolInstallerFolder}/bin`, { recursive: true, filter: binFileFilter }),
   ]);
 }
 


### PR DESCRIPTION
## Summary

- Adds a filter to `gulp/pack.mjs` that excludes `pac/_rels/.rels` and `pac_linux/_rels/.rels` when copying the pac CLI bin folder into the tool-installer staging directory
- These OPC metadata artifacts are extracted alongside the pac CLI NuGet package contents and confuse vsixsigntool.exe (ESRP) when it parses the VSIX as an OPC container — they reference non-existent targets, causing error **0x80510005**

## Test plan

- [ ] Run `npm run ci` locally — pack step should complete without errors
- [ ] Verify the produced VSIX no longer contains `bin/pac/_rels/.rels` or `bin/pac_linux/_rels/.rels`
- [ ] Queue official build (pipeline #21491) and confirm ESRP signing step passes

## Related

Fixes ICM 779156496

🤖 Generated with [Claude Code](https://claude.com/claude-code)