### PR TITLE
fix: make service endpoint contributions unique per stage in VSIX pack

### DIFF
--- a/gulp/pack.mjs
+++ b/gulp/pack.mjs
@@ -199,6 +199,21 @@ async function generateAllStages(manifest, taskVersion, manifestVersion) {
       stageManifest.public = false;
       stageManifest.name = `${stageManifest.name} ([${stage}] ${stageManifest.version})`;
       stageManifest.id = `${stageManifest.id}-${stage}`;
+      // Make service endpoint contribution names unique per stage to avoid Marketplace collision
+      stageManifest.contributions = stageManifest.contributions.map(contrib => {
+        if (contrib.type === "ms.vss-endpoint.service-endpoint-type") {
+          return {
+            ...contrib,
+            id: `${contrib.id}-${stage.toLowerCase()}`,
+            properties: {
+              ...contrib.properties,
+              name: `${contrib.properties.name}-${stage.toLowerCase()}`,
+              displayName: `${contrib.properties.displayName} [${stage}]`,
+            }
+          };
+        }
+        return contrib;
+      });
     } else {
       stageManifest.public = true;
       stageManifest.name = `${stageManifest.name} (${stageManifest.version})`;
@@ -216,6 +231,15 @@ async function generateAllStages(manifest, taskVersion, manifestVersion) {
       taskJson.id = taskInfo.id[stage];
       if (stage !== "LIVE") {
         taskJson.friendlyName += ` [${stage}]`;
+        // Update service endpoint reference to match the stage-specific endpoint name
+        if (taskJson.inputs) {
+          taskJson.inputs = taskJson.inputs.map(input => {
+            if (input.type && input.type.startsWith("connectedService:powerplatform-spn")) {
+              return { ...input, type: `connectedService:powerplatform-spn-${stage.toLowerCase()}` };
+            }
+            return input;
+          });
+        }
       }
       taskJson.version.Major = taskVersion.major;
       taskJson.version.Minor = taskVersion.minor;


### PR DESCRIPTION
## Summary
- Non-LIVE stages (BETA, DEV, EXPERIMENTAL) shared the same service endpoint contribution `id` and `name` as LIVE, causing **duplicate contribution id** errors when all four stage VSIXs are published to the Marketplace simultaneously
- For non-LIVE stages, suffixes the endpoint contribution `id` and `properties.name` with the lowercase stage name (e.g. `powerplatform-spn-beta`), and appends the stage label to `displayName`
- Updates each task's `connectedService:` input `type` to reference the stage-specific endpoint id, so tasks bind to the correct service endpoint at runtime

## Architecture impact
- `gulp/pack.mjs` — `generateAllStages()` only; no changes to `task.json` files or `BuildToolsHost`
- LIVE stage is unchanged — no impact on production pipelines

## Known limitations / follow-ups
- Existing BETA/DEV/EXPERIMENTAL service connections will not auto-migrate to the new endpoint type name; users would need to re-create them (only affects internal test pipelines)

## Test plan
- [ ] `npm run ci` passes (functional tests exempt)
- [ ] Inspect generated VSIX manifests: confirm BETA/DEV/EXPERIMENTAL have unique endpoint `id` values
- [ ] Confirm LIVE VSIX manifest is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)