### PR TITLE
feat: publish non-LIVE stage extensions publicly to VS Marketplace

### DIFF
--- a/gulp/pack.mjs
+++ b/gulp/pack.mjs
@@ -196,7 +196,7 @@ async function generateAllStages(manifest, taskVersion, manifestVersion) {
   for (const stage of stages) {
     const stageManifest = {...manifest};
     if (stage !== "LIVE") {
-      stageManifest.public = false;
+      stageManifest.public = true;
       stageManifest.name = `${stageManifest.name} ([${stage}] ${stageManifest.version})`;
       stageManifest.id = `${stageManifest.id}-${stage}`;
       // Make service endpoint contribution names unique per stage to avoid Marketplace collision


### PR DESCRIPTION
## Summary
- BETA, DEV, and EXPERIMENTAL stage VSIXs were marked `public: false`, keeping them unlisted on the Marketplace
- Setting `public: true` makes them discoverable so testers and preview users can install them without needing a direct link

## Architecture impact
- `gulp/pack.mjs` only — single line change in `generateAllStages()`
- No task, schema, or interface changes

## Known limitations / follow-ups
- None

## Test plan
- [ ] `npm run ci` passes (functional tests exempt)
- [ ] Inspect generated VSIX manifests: confirm BETA/DEV/EXPERIMENTAL have `"public": true`
- [ ] Confirm LIVE manifest is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)