### PR TITLE
feat: publish non-LIVE stage extensions publicly to VS Marketplace

### DIFF
--- a/gulp/pack.mjs
+++ b/gulp/pack.mjs
@@ -196,7 +196,7 @@ async function generateAllStages(manifest, taskVersion, manifestVersion) {
   for (const stage of stages) {
     const stageManifest = {...manifest};
     if (stage !== "LIVE") {
-      stageManifest.public = false;
+      stageManifest.public = true;
       stageManifest.name = `${stageManifest.name} ([${stage}] ${stageManifest.version})`;
       stageManifest.id = `${stageManifest.id}-${stage}`;
       // Make service endpoint contribution names unique per stage to avoid Marketplace collision


### PR DESCRIPTION
## Summary

Cherry-pick of #1356 to `release/stable`.

- Sets `public: true` for BETA/DEV/EXPERIMENTAL stage VSIXs so they are discoverable on the Marketplace

## Paired main PR
#1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)