### PR TITLE
Update pac CLI to 2.6.4

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -22,7 +22,7 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 # Release Notes
 
 {{NextReleaseVersion}}:
-- pac CLI 1.52, [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/1.52.1#releasenotes-body-tab)
+- pac CLI 2.6, [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.6.4#releasenotes-body-tab)
 
 2.0.97:
 - pac CLI 1.49, [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/1.49.4#releasenotes-body-tab)

--- a/nuget.json
+++ b/nuget.json
@@ -2,13 +2,13 @@
   "packages": [
     {
       "name": "Microsoft.PowerApps.CLI",
-      "version": "1.52.1",
+      "version": "2.6.4",
       "internalName": "pac",
       "useFeed": "nuget.org"
     },
     {
       "name": "Microsoft.PowerApps.CLI.Core.linux-x64",
-      "version": "1.52.1",
+      "version": "2.6.4",
       "internalName": "pac_linux",
       "chmod": "tools/pac",
       "useFeed": "nuget.org"


### PR DESCRIPTION
## Summary
- Bump PAC CLI from 1.52.1 to 2.6.4
- [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.6.4#releasenotes-body-tab)

## Changes
- `nuget.json`: both `Microsoft.PowerApps.CLI` and `Microsoft.PowerApps.CLI.Core.linux-x64` updated to `2.6.4`
- `extension/overview.md`: release notes entry added

## Test plan
- [ ] `npm run ci` passes locally (restore downloads new pac CLI version successfully)
- [ ] Functional tests exempt (require live env credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)