### PR TITLE
fix: add Override entries to VSIX [Content_Types].xml for extension-less pac CLI files

### DIFF
--- a/gulp/lib/nugetInstall.mjs
+++ b/gulp/lib/nugetInstall.mjs
@@ -66,9 +66,10 @@ export default async function nugetInstall(pkg, feeds) {
             targetDir,
             ...pkg.chmod.split(/[\\/]/g)
           );
-          chmod(exePath, 0o711);
+          chmod(exePath, 0o711).then(resolve).catch(reject);
+        } else {
+          resolve();
         }
-        resolve();
       })
       .on("error", reject);
   });

--- a/gulp/pack.mjs
+++ b/gulp/pack.mjs
@@ -6,10 +6,12 @@ import { createCommandRunner } from "@microsoft/powerplatform-cli-wrapper";
 import find from "find";
 import path from "path";
 import { rm } from "fs/promises";
+import { info } from "fancy-log";
 
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const tar = require("tar");
+const AdmZip = require("adm-zip");
 
 const outDir = 'out';
 const stagingDir = `${outDir}/staging`;
@@ -266,4 +268,73 @@ async function generateAllStages(manifest, taskVersion, manifestVersion) {
       outputPath: packagesDir,
     });
   }
+
+  // Fix [Content_Types].xml in all generated VSIX files to add Override entries for
+  // extension-less files inside the pac CLI directories.
+  //
+  // Background: VSIX files are OPC (Open Packaging Convention) containers. Every part
+  // (file) inside must be covered by [Content_Types].xml — either via a <Default> entry
+  // keyed on file extension, or via an <Override> entry keyed on the full part path.
+  //
+  // 'tfx extension create' only generates <Default> entries keyed on extensions, so any
+  // extension-less file gets no entry. When the VSIX is processed by OPC-aware tools
+  // (e.g. the AzDO Marketplace ingestion pipeline), any part not registered in
+  // [Content_Types].xml is silently dropped from the output package.
+  //
+  // Known extension-less files in bin/pac* that must be preserved:
+  //   bin/pac_linux/tools/pac                              — Linux PAC CLI executable
+  //   bin/pac*/tools/.playwright/.../xdg-open              — used by Playwright for browser auth flows
+  //   bin/pac*/tools/.playwright/.../LICENSE|NOTICE        — license text (harmless but included for completeness)
+  //
+  // Note: _rels/.rels files are already excluded during copyDependencies() so they never
+  // reach the VSIX and do not need to be handled here.
+  async function fixVsixContentTypes() {
+    // Match any extension-less file inside the pac or pac_linux tool directories.
+    const PAC_DIR_PATTERN = /^tasks\/tool-installer\/tool-installer-v2\/bin\/pac[^/]*\//;
+
+    const vsixFiles = await findFiles(/\.vsix$/, packagesDir);
+    for (const vsixPath of vsixFiles) {
+      const zip = new AdmZip(vsixPath);
+      const ctEntry = zip.getEntry('[Content_Types].xml');
+      if (!ctEntry) {
+        throw new Error(`[Content_Types].xml not found in ${vsixPath}`);
+      }
+
+      const ctXml = ctEntry.getData().toString('utf8');
+
+      // Collect part paths already covered by <Override> entries (strip leading '/').
+      const overridePaths = new Set(
+        [...ctXml.matchAll(/PartName="([^"]+)"/g)].map(m => m[1].replace(/^\//, ''))
+      );
+
+      // Find all extension-less files inside the pac directories that are missing an Override.
+      const newOverrides = [];
+      for (const entry of zip.getEntries()) {
+        if (entry.isDirectory) continue;
+        const entryName = entry.entryName.replace(/\\/g, '/');
+        const hasNoExtension = path.extname(entryName) === '';
+        if (PAC_DIR_PATTERN.test(entryName) && hasNoExtension && !overridePaths.has(entryName)) {
+          newOverrides.push(
+            `  <Override ContentType="application/octet-stream" PartName="/${entryName}"/>`
+          );
+        }
+      }
+
+      if (newOverrides.length > 0) {
+        const modified = ctXml.replace(
+          '</Types>',
+          newOverrides.join('\n') + '\n</Types>'
+        );
+        zip.updateFile('[Content_Types].xml', Buffer.from(modified, 'utf8'));
+        zip.writeZip(vsixPath);
+        info(
+          `Fixed [Content_Types].xml in ${path.basename(vsixPath)}: ` +
+          `added ${newOverrides.length} Override entr${newOverrides.length === 1 ? 'y' : 'ies'} ` +
+          `(${newOverrides.map(o => /PartName="\/([^"]+)"/.exec(o)?.[1]).join(', ')})`
+        );
+      }
+    }
+  }
+
+  await fixVsixContentTypes();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/webpack": "^5.28.5",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
+        "adm-zip": "^0.5.16",
         "chai": "^4.5.0",
         "dotenv": "^16.4.5",
         "eslint": "^8.50.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/webpack": "^5.28.5",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
+    "adm-zip": "^0.5.16",
     "chai": "^4.5.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.50.0",

--- a/src/host/CliLocator.ts
+++ b/src/host/CliLocator.ts
@@ -17,13 +17,17 @@ export async function findPacCLIPath(): Promise<{ pacRootPath: string, pacPath: 
       break;
     case 'linux':
       pacPath = path.resolve(pacRootPath, 'pac_linux', 'tools', 'pac');
-      await chmod(pacPath, 0o711);
       break;
     default:
       throw new Error(`Unsupported OS for tool-installer: ${process.platform}`);
   }
   if (!await pathExists(pacPath)) {
     throw new Error(`Cannot find required pac CLI executable under: ${pacPath}`);
+  }
+  // chmod must come after the pathExists check so that a missing-file error is reported
+  // clearly rather than surfacing as a confusing ENOENT from chmod itself.
+  if (process.platform === 'linux') {
+    await chmod(pacPath, 0o711);
   }
 
   pacPath = pacPath.replace(/(\/|\\)(pac.exe|pac)$/, '');


### PR DESCRIPTION
## Summary
- `[Content_Types].xml` in generated VSIX files only has `<Default>` entries keyed on file extension — extension-less files (Linux PAC CLI executable, Playwright binaries) get no entry and are silently dropped by OPC-aware tools (e.g. ESRP signing pipeline)
- Adds a `fixVsixContentTypes()` post-processing step that inserts `<Override>` entries for all extension-less files inside `bin/pac*` directories
- Moves `chmod` in `CliLocator.ts` to after `pathExists` check so missing-file errors surface clearly
- Fixes promise resolve/reject ordering in `nugetInstall.mjs` for the chmod path

## Tasks affected
- `tool-installer` — VSIX now correctly preserves Linux pac CLI executable and Playwright binaries after OPC processing

## Known limitations / follow-ups
- `adm-zip` added as dev dependency for VSIX post-processing

## Test plan
- [ ] `npm run ci` passes (functional tests exempt)
- [ ] VSIX content types verified: `unzip -p *.vsix '[Content_Types].xml'` shows Override entries for extension-less files

🤖 Generated with [Claude Code](https://claude.com/claude-code)