### PR TITLE
chore: upgrade actions/checkout to v6 for Node24 support

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -48,7 +48,7 @@ jobs:
           echo "Detected version: $VERSION (run: $RUN_ID)"
 
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
           git push
 
       - name: Checkout release/stable
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: release/stable
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout@v4` → `@v6` in `.github/workflows/post-release.yml`
- v6 supports Node 24, which becomes the default GitHub Actions runner runtime on **June 2, 2026** ([deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/))
- v4 still works today but will be removed when Node 20 is fully retired in fall 2026

## Action items (separate from this PR)
The `Stamp release notes and publish GitHub release after publish` workflow is currently **disabled_manually**. Recent v* tag pushes (v2.0.133, v2.0.134, v2.0.135, v2.0.136) did not trigger it. To re-enable:
1. Verify `AZ_DevOps_Read_PAT` secret is configured in repo settings
2. Verify branch protection bypass for `github-actions[bot]` on `main` and `release/stable`
3. Re-enable the workflow in the Actions tab

## Test plan
- [ ] Workflow YAML still parses correctly
- [ ] After re-enabling, a `v*` tag push triggers the workflow successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)