### PR TITLE
fix: validate PAC CLI path to prevent mutable variable hijack

### DIFF
--- a/src/host/BuildToolsRunnerParams.ts
+++ b/src/host/BuildToolsRunnerParams.ts
@@ -2,12 +2,54 @@
 // Licensed under the MIT License.
 
 import * as tl from 'azure-pipelines-task-lib/task';
+import path = require('path');
 import { Logger, RunnerParameters } from "@microsoft/powerplatform-cli-wrapper";
 import { cwd } from "process";
 import buildToolsLogger from "./logger";
 
 const EnvVarPrefix = 'POWERPLATFORMTOOLS_';
 export const PacPathEnvVarName = `${EnvVarPrefix}PACCLIPATH`;
+
+// Known task GUIDs for PowerPlatformToolInstaller across all release stages.
+// The PAC CLI binary is only installed by this task, so a valid PAC path must
+// reside under a directory named with one of these GUIDs.
+const ToolInstallerTaskGuids: ReadonlyArray<string> = [
+  '8015465b-f367-4ec4-8215-8edf682574d3', // LIVE
+  'a4243e47-8809-429e-bda4-624757b874b5', // BETA
+  'bbb104f9-1acc-4584-8b09-93b8e2373659', // DEV
+  '133b55b8-c51f-4ceb-8270-6d68c0cac6e4', // EXPERIMENTAL
+];
+
+/**
+ * Validates that a PAC CLI path originates from the official ToolInstaller task directory.
+ * This prevents a low-trust build step from redirecting protected tasks to an
+ * attacker-controlled PAC binary by overwriting the job-scoped PACCLIPATH variable.
+ */
+export function validatePacPath(pacPath: string): void {
+  const normalizedPath = path.resolve(pacPath).toLowerCase().replace(/\\/g, '/');
+
+  // The path must be under the agent's _tasks directory
+  if (!normalizedPath.includes('/_tasks/')) {
+    throw new Error(
+      `Security validation failed: PAC CLI path "${pacPath}" is not under the agent's _tasks directory. ` +
+      `The PAC CLI must be resolved from the official PowerPlatformToolInstaller task. ` +
+      `Ensure that PowerPlatformToolInstaller@2 runs before this task and that ` +
+      `the ${PacPathEnvVarName} variable has not been modified by other pipeline steps.`
+    );
+  }
+
+  // The path must contain one of the known ToolInstaller task GUIDs
+  const hasValidGuid = ToolInstallerTaskGuids.some(guid =>
+    normalizedPath.includes(`/powerplatformtoolinstaller_${guid}`)
+  );
+  if (!hasValidGuid) {
+    throw new Error(
+      `Security validation failed: PAC CLI path "${pacPath}" does not reference a known ` +
+      `PowerPlatformToolInstaller task GUID. The PAC CLI must be executed from the official ` +
+      `ToolInstaller task directory. Ensure that ${PacPathEnvVarName} has not been tampered with.`
+    );
+  }
+}
 
 export class BuildToolsRunnerParams implements RunnerParameters {
   private _workingDir: string;
@@ -37,7 +79,8 @@ export class BuildToolsRunnerParams implements RunnerParameters {
           throw new Error(`Cannot find required pac CLI, Tool-Installer task was not called before this task!`);
         }
       }
-      this._runnersDir = (pacPath as string);
+      validatePacPath(pacPath);
+      this._runnersDir = pacPath;
     }
     return this._runnersDir;
   }

--- a/test/unit-test/pac-path-validation.test.ts
+++ b/test/unit-test/pac-path-validation.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { assert, should, use } from "chai";
+import * as sinonChai from "sinon-chai";
+import { validatePacPath, PacPathEnvVarName } from "../../src/host/BuildToolsRunnerParams";
+
+should();
+use(sinonChai);
+
+describe("PAC CLI path validation", () => {
+
+  describe("validatePacPath - valid paths", () => {
+    it("accepts Linux LIVE task path", () => {
+      const validPath = "/home/vsts/work/_tasks/PowerPlatformToolInstaller_8015465b-f367-4ec4-8215-8edf682574d3/2.0.137/bin";
+      assert.doesNotThrow(() => validatePacPath(validPath));
+    });
+
+    it("accepts Windows LIVE task path", () => {
+      const validPath = "C:\\agent\\_work\\_tasks\\PowerPlatformToolInstaller_8015465b-f367-4ec4-8215-8edf682574d3\\2.0.137\\bin";
+      assert.doesNotThrow(() => validatePacPath(validPath));
+    });
+
+    it("accepts BETA task GUID path", () => {
+      const validPath = "/home/vsts/work/_tasks/PowerPlatformToolInstaller_a4243e47-8809-429e-bda4-624757b874b5/2.0.137/bin";
+      assert.doesNotThrow(() => validatePacPath(validPath));
+    });
+
+    it("accepts DEV task GUID path", () => {
+      const validPath = "/home/vsts/work/_tasks/PowerPlatformToolInstaller_bbb104f9-1acc-4584-8b09-93b8e2373659/2.0.137/bin";
+      assert.doesNotThrow(() => validatePacPath(validPath));
+    });
+
+    it("accepts EXPERIMENTAL task GUID path", () => {
+      const validPath = "/home/vsts/work/_tasks/PowerPlatformToolInstaller_133b55b8-c51f-4ceb-8270-6d68c0cac6e4/2.0.137/bin";
+      assert.doesNotThrow(() => validatePacPath(validPath));
+    });
+
+    it("accepts path with mixed case in ToolInstaller directory name", () => {
+      const validPath = "/home/vsts/work/_tasks/powerplatformtoolinstaller_8015465b-f367-4ec4-8215-8edf682574d3/2.0.137/bin";
+      assert.doesNotThrow(() => validatePacPath(validPath));
+    });
+  });
+
+  describe("validatePacPath - rejects attacker paths", () => {
+    it("rejects /tmp path (attacker-controlled)", () => {
+      const attackerPath = "/tmp/ppbt-pac-root";
+      assert.throws(() => validatePacPath(attackerPath), /Security validation failed.*not under the agent's _tasks directory/);
+    });
+
+    it("rejects source directory path", () => {
+      const attackerPath = "/home/vsts/work/1/s/fake-pac";
+      assert.throws(() => validatePacPath(attackerPath), /Security validation failed.*not under the agent's _tasks directory/);
+    });
+
+    it("rejects pipeline workspace path", () => {
+      const attackerPath = "/home/vsts/work/1/a/malicious-pac";
+      assert.throws(() => validatePacPath(attackerPath), /Security validation failed.*not under the agent's _tasks directory/);
+    });
+
+    it("rejects path under _tasks but with wrong task GUID", () => {
+      const attackerPath = "/home/vsts/work/_tasks/SomeOtherTask_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/1.0.0/bin";
+      assert.throws(() => validatePacPath(attackerPath), /Security validation failed.*does not reference a known/);
+    });
+
+    it("rejects path that contains _tasks as a substring but not as a directory", () => {
+      const attackerPath = "/tmp/fake_tasks_dir/pac";
+      assert.throws(() => validatePacPath(attackerPath), /Security validation failed/);
+    });
+
+    it("rejects Windows temp path", () => {
+      const attackerPath = "C:\\Users\\vsts\\AppData\\Local\\Temp\\ppbt-pac-root";
+      assert.throws(() => validatePacPath(attackerPath), /Security validation failed.*not under the agent's _tasks directory/);
+    });
+
+    it("rejects path with _tasks but fabricated GUID mimicking installer", () => {
+      const attackerPath = "/home/vsts/work/_tasks/PowerPlatformToolInstaller_00000000-0000-0000-0000-000000000000/1.0.0/bin";
+      assert.throws(() => validatePacPath(attackerPath), /Security validation failed.*does not reference a known/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Cherry-pick of #1386 to `release/stable`.

- Adds PAC CLI path validation to prevent mutable job-scoped variable hijack (MSRC 117157 / ADO #6414246).

## Paired main PR
#1386

:robot: Generated with [Claude Code](https://claude.com/claude-code)