### PR TITLE
fix: mask SPN clientSecret and password via tl.setSecret (MSRC 117102, #6430957)

### DIFF
--- a/src/params/auth/getCredentials.ts
+++ b/src/params/auth/getCredentials.ts
@@ -54,6 +54,10 @@ function getClientCredentials(): AuthCredentials {
     // pipeline logs and in task-lib debug output (e.g. `auth param clientSecret = ...`).
     // Mitigates MSRC 117102: clientSecret previously appeared unmasked in pipeline logs.
     tl.setSecret(clientSecret);
+    // Also mask the base64-encoded form, because the cli-wrapper passes the secret to
+    // pac as `data:text/plain;base64,<base64>` — without this, the encoded form would
+    // not be masked in pipeline logs.
+    tl.setSecret(Buffer.from(clientSecret, 'binary').toString('base64'));
   }
 
   return {
@@ -93,6 +97,10 @@ function getUsernamePassword(): UsernamePassword {
     // pipeline logs and in task-lib debug output (e.g. `auth param password = ...`).
     // Mitigates MSRC 117102: password previously appeared unmasked in pipeline logs.
     tl.setSecret(password);
+    // Also mask the base64-encoded form, because the cli-wrapper passes the password
+    // to pac as `data:text/plain;base64,<base64>` — without this, the encoded form
+    // would not be masked in pipeline logs.
+    tl.setSecret(Buffer.from(password, 'binary').toString('base64'));
   }
   return {
     username: authorization.parameters.username,

--- a/src/params/auth/getCredentials.ts
+++ b/src/params/auth/getCredentials.ts
@@ -48,10 +48,18 @@ function getClientCredentials(): AuthCredentials {
     };
   }
 
+  const clientSecret = authorization.parameters.clientSecret;
+  if (clientSecret) {
+    // Register the Service Principal secret with task-lib so it is masked in
+    // pipeline logs and in task-lib debug output (e.g. `auth param clientSecret = ...`).
+    // Mitigates MSRC 117102: clientSecret previously appeared unmasked in pipeline logs.
+    tl.setSecret(clientSecret);
+  }
+
   return {
     tenantId: authorization.parameters.tenantId,
     appId: authorization.parameters.applicationId,
-    clientSecret: authorization.parameters.clientSecret,
+    clientSecret: clientSecret,
     encodeSecret: true,
     cloudInstance: resolveCloudInstance(endpointName),
     scheme: authorization.scheme
@@ -79,9 +87,16 @@ function buildIdTokenRequestUrl(): string {
 function getUsernamePassword(): UsernamePassword {
   const endpointName = getEndpointName("PowerPlatformEnvironment");
   const authorization = getEndpointAuthorizationParameters(endpointName);
+  const password = authorization.parameters.password;
+  if (password) {
+    // Register the username/password credential with task-lib so it is masked in
+    // pipeline logs and in task-lib debug output (e.g. `auth param password = ...`).
+    // Mitigates MSRC 117102: password previously appeared unmasked in pipeline logs.
+    tl.setSecret(password);
+  }
   return {
     username: authorization.parameters.username,
-    password: authorization.parameters.password,
+    password: password,
     encodePassword: true,
     cloudInstance: resolveCloudInstance(endpointName)
   };


### PR DESCRIPTION
## Summary
- Calls `tl.setSecret()` on the SPN `clientSecret` and the username/password `password` immediately after they are read from the Azure DevOps service connection in `getCredentials.ts`.
- Mitigates **MSRC 117102 (Sev 1)**: these credentials previously appeared **unmasked** in pipeline logs and in task-lib debug output (e.g. `auth param clientSecret = <VALUE>` when `System.Debug=true`).
- Mirrors the pre-existing `tl.setSecret()` pattern already used for the OIDC `PAC_ADO_ID_TOKEN_REQUEST_TOKEN` value in the same file.

Work item: [ADO 6430957](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/6430957)

## Tasks affected
All 29 tasks that authenticate via `PowerPlatformSPN` or `PowerPlatformEnvironment` service connections (every task that calls `getCredentials()` — i.e. all auth-using tasks). Behavior is unchanged; the credential values are now registered as secrets with `azure-pipelines-task-lib` so they are masked anywhere they are echoed.

## Architecture impact
None. No task input names, `task.json` contracts, `BuildToolsHost`/`BuildToolsRunnerParams` interfaces, or bundled-dependency boundaries change. The change is confined to `src/params/auth/getCredentials.ts`.

## Known limitations / follow-ups
This PR addresses the **pipeline-log and task-lib-debug** exposure paths only. Two other exposure vectors called out in the MSRC report live in `@microsoft/powerplatform-cli-wrapper` (the `pac auth create` invocation) and must be fixed upstream:

- `/proc/<pid>/cmdline` — `--clientSecret data:text/plain;base64,<VALUE>` is passed as a CLI argument; readable by any concurrent process on the build agent.
- `/proc/<pid>/environ` — `PAC_CLI_SPN_SECRET=<VALUE>` is placed in the process environment and inherited by children.

Suggested upstream fixes (cli-wrapper): switch to `--clientSecret-stdin` or env-only credential passing, and drop the base64 sugar that gives a false sense of security.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 41 tests pass; 4 pre-existing failures in `copy-environment` / `create-environment` / `reset-environment` / `restore-environment` task tests are unrelated TS typing issues on `EnvironmentResult` (present on `origin/main`)
- [ ] Manual pipeline run on DEV stage with `System.Debug=true` — confirm `clientSecret` and `password` are rendered as `***` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)