### PR TITLE
fix: mask SPN clientSecret and password via tl.setSecret (MSRC 117102, #6430957)

### DIFF
--- a/src/params/auth/getCredentials.ts
+++ b/src/params/auth/getCredentials.ts
@@ -54,6 +54,10 @@ function getClientCredentials(): AuthCredentials {
     // pipeline logs and in task-lib debug output (e.g. `auth param clientSecret = ...`).
     // Mitigates MSRC 117102: clientSecret previously appeared unmasked in pipeline logs.
     tl.setSecret(clientSecret);
+    // Also mask the base64-encoded form, because the cli-wrapper passes the secret to
+    // pac as `data:text/plain;base64,<base64>` — without this, the encoded form would
+    // not be masked in pipeline logs.
+    tl.setSecret(Buffer.from(clientSecret, 'binary').toString('base64'));
   }
 
   return {
@@ -93,6 +97,10 @@ function getUsernamePassword(): UsernamePassword {
     // pipeline logs and in task-lib debug output (e.g. `auth param password = ...`).
     // Mitigates MSRC 117102: password previously appeared unmasked in pipeline logs.
     tl.setSecret(password);
+    // Also mask the base64-encoded form, because the cli-wrapper passes the password
+    // to pac as `data:text/plain;base64,<base64>` — without this, the encoded form
+    // would not be masked in pipeline logs.
+    tl.setSecret(Buffer.from(password, 'binary').toString('base64'));
   }
   return {
     username: authorization.parameters.username,

--- a/src/params/auth/getCredentials.ts
+++ b/src/params/auth/getCredentials.ts
@@ -48,10 +48,18 @@ function getClientCredentials(): AuthCredentials {
     };
   }
 
+  const clientSecret = authorization.parameters.clientSecret;
+  if (clientSecret) {
+    // Register the Service Principal secret with task-lib so it is masked in
+    // pipeline logs and in task-lib debug output (e.g. `auth param clientSecret = ...`).
+    // Mitigates MSRC 117102: clientSecret previously appeared unmasked in pipeline logs.
+    tl.setSecret(clientSecret);
+  }
+
   return {
     tenantId: authorization.parameters.tenantId,
     appId: authorization.parameters.applicationId,
-    clientSecret: authorization.parameters.clientSecret,
+    clientSecret: clientSecret,
     encodeSecret: true,
     cloudInstance: resolveCloudInstance(endpointName),
     scheme: authorization.scheme
@@ -79,9 +87,16 @@ function buildIdTokenRequestUrl(): string {
 function getUsernamePassword(): UsernamePassword {
   const endpointName = getEndpointName("PowerPlatformEnvironment");
   const authorization = getEndpointAuthorizationParameters(endpointName);
+  const password = authorization.parameters.password;
+  if (password) {
+    // Register the username/password credential with task-lib so it is masked in
+    // pipeline logs and in task-lib debug output (e.g. `auth param password = ...`).
+    // Mitigates MSRC 117102: password previously appeared unmasked in pipeline logs.
+    tl.setSecret(password);
+  }
   return {
     username: authorization.parameters.username,
-    password: authorization.parameters.password,
+    password: password,
     encodePassword: true,
     cloudInstance: resolveCloudInstance(endpointName)
   };


### PR DESCRIPTION
## Summary

Cherry-pick of #1389 to `release/stable`.

- Calls `tl.setSecret()` on the SPN `clientSecret` and the username/password `password` so they are masked in pipeline logs and task-lib debug output.
- Mitigates **MSRC 117102 (Sev 1)** — pipeline-log / task-lib-debug exposure paths.

Work item: [ADO 6430957](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/6430957)

## Paired main PR
#1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)