### PR TITLE
[release] revert: pac CLI 2.8.1 -> 2.7.4 due to upstream bug

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -22,6 +22,9 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 # Release Notes
 
 {{NextReleaseVersion}}:
+- pac CLI 2.7, [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.7.4#releasenotes-body-tab) (revert from 2.8.1)
+
+2.0.145:
 - pac CLI 2.8, [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.8.1#releasenotes-body-tab)
 
 2.0.140:

--- a/nuget.json
+++ b/nuget.json
@@ -2,13 +2,13 @@
   "packages": [
     {
       "name": "Microsoft.PowerApps.CLI",
-      "version": "2.8.1",
+      "version": "2.7.4",
       "internalName": "pac",
       "useFeed": "nuget.org"
     },
     {
       "name": "Microsoft.PowerApps.CLI.Core.linux-x64",
-      "version": "2.8.1",
+      "version": "2.7.4",
       "internalName": "pac_linux",
       "chmod": "tools/pac",
       "useFeed": "nuget.org"


### PR DESCRIPTION
## Summary
- Revert PAC CLI from 2.8.1 back to 2.7.4 on the release/stable branch due to an upstream bug in 2.8.1
- Mirrors: https://github.com/microsoft/powerplatform-build-tools/pull/1397

## Changes
- `nuget.json`: both packages reverted to `2.7.4`
- `extension/overview.md`: additive — `2.8` history preserved under `2.0.145:`, new entry under `{{NextReleaseVersion}}:` flagged as revert from 2.8.1

## Test plan
- [ ] Main-branch PR verified first
- [ ] Functional tests exempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)