### PR TITLE
fix: bump brace-expansion + picomatch to patched versions (S360 CVEs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -857,9 +857,9 @@
       }
     },
     "node_modules/@microsoft/powerplatform-cli-wrapper/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6047,6 +6047,29 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -8502,9 +8525,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8591,6 +8614,29 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/mocha/node_modules/cliui": {
@@ -9721,9 +9767,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10230,6 +10276,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
@@ -11999,9 +12068,9 @@
       }
     },
     "node_modules/tfx-cli/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,10 @@
     "diff": "^5.2.0",
     "ajv": "^6.12.6",
     "underscore": "^1.13.8",
-    "bn.js": "^5.2.3"
+    "bn.js": "^5.2.3",
+    "minimatch": {
+      "brace-expansion": "^5.0.6"
+    }
   },
   "dependencies": {
     "@microsoft/powerplatform-cli-wrapper": "^0.1.135",


### PR DESCRIPTION
## Summary

Closes 4 PPBT S360 work items on KPI 240c2bea-0698-48c7-8e78-f9beac31a861 (BIC Component Governance - Low/Medium action items):

| ADO | Package | S360 target | This PR |
| --- | --- | --- | --- |
| AB#6364952 | brace-expansion 1.1.12 | 1.1.13 (CVE-2026-33750) | 1.1.15 |
| AB#6364953 | brace-expansion 2.0.2 | 2.0.3 (CVE-2026-33750) | 2.0.3 |
| AB#6364954 | picomatch 2.3.1 | 2.3.2 (CVE-2026-33672) | 2.3.2 |
| AB#6364955 | brace-expansion 5.0.4 | 5.0.5 (CVE-2026-33750) | 5.0.6 |

Bonus coverage on AB#6408700 (brace-expansion 5.0.4 → 5.0.6, CVE-2026-45149) — same 5.x paths.

## Mechanism

### `package.json` overrides
- Existing `brace-expansion: "^2.0.3"` direct dep fixes the hoisted root 2.x.
- Added `"minimatch": { "brace-expansion": "^5.0.6" }` — overrides every minimatch's brace-expansion to ≥5.0.6, fixing `glob`, `mocha`, `readdir-glob`, `tfx-cli`.

### Lock-file patches for `inBundle: true` paths
npm overrides do not reach packages marked `inBundle: true` (memory: dependency hard rules). Manually updated:

- `node_modules/@microsoft/powerplatform-cli-wrapper/node_modules/brace-expansion`: 5.0.4 → 5.0.6
- `node_modules/minimatch/node_modules/brace-expansion` (azure-pipelines-task-lib bundled): 1.1.12 → 1.1.15
- `node_modules/picomatch` (inBundle=true): 2.3.1 → 2.3.2

Each patch includes the npm-published \`integrity\` hash.

## Result

All brace-expansion entries in \`package-lock.json\`:
- 1.1.15 (was 1.1.12)
- 2.0.3 (was 2.0.2)
- 5.0.6 (was 5.0.4, 4 paths)

All picomatch entries:
- 2.3.2 (was 2.3.1, inBundle path)
- 4.0.3 (already current, unchanged)

## Test plan

- [x] \`npm audit\` no longer reports brace-expansion or picomatch findings
- [x] compile + lint + restore (pac CLI 2.7.4) pass
- [ ] CI on PR — full pipeline including unit tests on Node 20 (local Node 24 has a pre-existing ts-strip incompatibility unrelated to this change)

## Not in this PR

- AB#6420216 (uuid 3.4.0 → 11.1.1, CVE-2026-41907): area path is Deployment Hub\Admin, routed to a different team's queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)