### PR TITLE
docs(skills): document auto-created GitHub Release after pipeline succeeds

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -162,4 +162,14 @@ When queuing, set these pipeline variables:
   - AZ_DevOps_Read_PAT      PAT to read from the AzDO DPX-Tools-Upstream feed
   - isEsrpEnabled           true
   - PUBLISH_TO_MARKETPLACE  true
+
+When the pipeline succeeds, the build automatically:
+  - Pushes a v<version> tag (e.g. v2.0.147) to the repo
+  - Signs and publishes the VSIXs to the VS Marketplace
+  - Creates a published GitHub Release with all 4 signed VSIXs attached, marked Latest
+
+Verify the release at:
+  https://github.com/microsoft/powerplatform-build-tools/releases/tag/v<version>
+
+If no GitHub Release shows up after a successful build, inspect the "Create GitHub release with VSIX assets" task in the ADO build logs — most likely cause is the GITHUB_TOKEN pipeline variable being missing, expired, or lacking `repo` scope / SSO authorization for `microsoft`.
 ```

--- a/.claude/skills/pac-cli-update/SKILL.md
+++ b/.claude/skills/pac-cli-update/SKILL.md
@@ -204,6 +204,29 @@ Print:
 4. **Release PR:** URL
 5. **Restore verified:** yes / no (did `gulp restore` download the new pac CLI successfully?)
 
+Then tell the user what to do after both PRs merge:
+
+```
+Once both PRs merge, queue the official build to sign, publish to Marketplace, and create the GitHub Release:
+  https://dev.azure.com/dynamicscrm/OneCRM/_build?definitionId=21491
+
+Pipeline variables to set when queuing:
+  - GITHUB_TOKEN            GitHub PAT (repo scope, SSO enabled for 'microsoft' org)
+  - AZ_DevOps_Read_PAT      PAT to read from the AzDO DPX-Tools-Upstream feed
+  - isEsrpEnabled           true
+  - PUBLISH_TO_MARKETPLACE  true
+
+On success, a published GitHub Release will appear automatically at:
+  https://github.com/microsoft/powerplatform-build-tools/releases/tag/v<new-extension-version>
+
+That release will include:
+  - All 4 signed VSIXs (LIVE, BETA, DEV, EXPERIMENTAL) as assets
+  - Release notes extracted from `extension/overview.md`'s `{{NextReleaseVersion}}:` block
+  - Latest tag
+
+If the release does not appear, check the "Create GitHub release with VSIX assets" task in the build log — usually GITHUB_TOKEN scope or SSO authorization is the issue.
+```
+
 ---
 
 ## Hard rules


### PR DESCRIPTION
## Summary

After the BIC official build pipeline learned to auto-create the GitHub Release on publish (the \`Create GitHub release with VSIX assets\` PowerShell task added to the pipeline YAML earlier this session), both AI skills should mention the auto-created release URL so contributors know where to find their build output.

## Changes

- \`.claude/skills/create-pr/SKILL.md\` — Step 4 "Prompt user to queue the official build" now appends the post-pipeline expectation: tag pushed, VSIXs published, GitHub Release auto-created at \`/releases/tag/v<version>\`. Includes a troubleshooting pointer (GITHUB_TOKEN scope / SSO) if the release doesn't appear.
- \`.claude/skills/pac-cli-update/SKILL.md\` — Step 9 "Final summary" gets the same post-pipeline guidance, formatted as a user-facing prompt with the same troubleshooting hint.

## Why
- Eliminates the manual "draft a new release on GitHub" step from the post-PAC-bump checklist.
- New contributors invoking \`/pac-cli-update\` or \`/create-pr\` will see the predictable release URL and know to look there instead of asking for it.

## Test plan
- [x] Both SKILL.md files parse and render correctly
- [ ] Next \`/pac-cli-update\` or \`/create-pr\` invocation surfaces the new guidance in its final output

🤖 Generated with [Claude Code](https://claude.com/claude-code)