### PR TITLE
[release] docs(skills): document auto-created GitHub Release after pipeline succeeds

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -162,4 +162,14 @@ When queuing, set these pipeline variables:
   - AZ_DevOps_Read_PAT      PAT to read from the AzDO DPX-Tools-Upstream feed
   - isEsrpEnabled           true
   - PUBLISH_TO_MARKETPLACE  true
+
+When the pipeline succeeds, the build automatically:
+  - Pushes a v<version> tag (e.g. v2.0.147) to the repo
+  - Signs and publishes the VSIXs to the VS Marketplace
+  - Creates a published GitHub Release with all 4 signed VSIXs attached, marked Latest
+
+Verify the release at:
+  https://github.com/microsoft/powerplatform-build-tools/releases/tag/v<version>
+
+If no GitHub Release shows up after a successful build, inspect the "Create GitHub release with VSIX assets" task in the ADO build logs — most likely cause is the GITHUB_TOKEN pipeline variable being missing, expired, or lacking `repo` scope / SSO authorization for `microsoft`.
 ```

--- a/.claude/skills/pac-cli-update/SKILL.md
+++ b/.claude/skills/pac-cli-update/SKILL.md
@@ -204,6 +204,29 @@ Print:
 4. **Release PR:** URL
 5. **Restore verified:** yes / no (did `gulp restore` download the new pac CLI successfully?)
 
+Then tell the user what to do after both PRs merge:
+
+```
+Once both PRs merge, queue the official build to sign, publish to Marketplace, and create the GitHub Release:
+  https://dev.azure.com/dynamicscrm/OneCRM/_build?definitionId=21491
+
+Pipeline variables to set when queuing:
+  - GITHUB_TOKEN            GitHub PAT (repo scope, SSO enabled for 'microsoft' org)
+  - AZ_DevOps_Read_PAT      PAT to read from the AzDO DPX-Tools-Upstream feed
+  - isEsrpEnabled           true
+  - PUBLISH_TO_MARKETPLACE  true
+
+On success, a published GitHub Release will appear automatically at:
+  https://github.com/microsoft/powerplatform-build-tools/releases/tag/v<new-extension-version>
+
+That release will include:
+  - All 4 signed VSIXs (LIVE, BETA, DEV, EXPERIMENTAL) as assets
+  - Release notes extracted from `extension/overview.md`'s `{{NextReleaseVersion}}:` block
+  - Latest tag
+
+If the release does not appear, check the "Create GitHub release with VSIX assets" task in the build log — usually GITHUB_TOKEN scope or SSO authorization is the issue.
+```
+
 ---
 
 ## Hard rules


### PR DESCRIPTION
## Summary

Cherry-pick of #1402 to \`release/stable\` for branch parity.

Skill docs are local to the repo (Claude Code agent reads them from the working tree), so the practical impact of having them on release/stable is small — but keeping branches in sync prevents drift on future skill edits cherry-picked across both branches.

## Paired main PR
#1402

## Test plan
- [ ] Main-branch PR #1402 verified first

🤖 Generated with [Claude Code](https://claude.com/claude-code)