### PR TITLE
chore: fix dependency vulnerabilities (28 -> 8, all highs resolved)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "sinon": "^16.1.0",
         "sinon-chai": "^3.6.0",
         "sync-request": "^6.1.0",
-        "tar": "^7.5.11",
+        "tar": "^7.5.16",
         "tfx-cli": "^0.23.1",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.2",
@@ -2777,9 +2777,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-6.0.1.tgz",
+      "integrity": "sha512-3ilxa3n4276wGQp/ImRAuz4ALdsj/2Wd3FqoZBZlajDYnByCZ0JMb4+26Rde0wGXIbM0G2HWSfr/Fi8b21KX8g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4296,9 +4296,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
-      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5565,9 +5565,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -5649,16 +5649,16 @@
       "license": "BSD"
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -6878,9 +6878,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7994,10 +7994,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9897,9 +9907,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -9917,7 +9927,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10138,9 +10148,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -11018,9 +11028,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -11864,9 +11874,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -12165,9 +12175,9 @@
       }
     },
     "node_modules/tfx-cli/node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -12296,9 +12306,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12319,9 +12329,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12925,9 +12935,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sinon": "^16.1.0",
     "sinon-chai": "^3.6.0",
     "sync-request": "^6.1.0",
-    "tar": "^7.5.11",
+    "tar": "^7.5.16",
     "tfx-cli": "^0.23.1",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
@@ -79,16 +79,30 @@
     "@types/node": "~24.3.0",
     "nanoid": "3.3.11",
     "electron-to-chromium": "1.5.250",
-    "basic-ftp": "^5.3.0",
-    "serialize-javascript": "^7.0.3",
-    "postcss": "^8.4.31",
-    "qs": "^6.14.2",
+    "basic-ftp": "^6.0.1",
+    "serialize-javascript": "^7.0.5",
+    "postcss": "^8.5.15",
+    "qs": "^6.15.2",
     "diff": "^5.2.0",
     "ajv": "^6.12.6",
     "underscore": "^1.13.8",
     "bn.js": "^5.2.3",
+    "tmp": "^0.2.7",
+    "undici": "^6.24.0",
+    "defu": "^6.1.7",
+    "flatted": "^3.4.2",
+    "form-data": "^2.5.6",
+    "ip-address": "^10.2.0",
+    "js-yaml": "^4.2.0",
+    "lodash": "^4.18.1",
     "minimatch": {
       "brace-expansion": "^5.0.6"
+    },
+    "tinyglobby": {
+      "picomatch": "^4.0.4"
+    },
+    "tfx-cli": {
+      "uuid": "^13.0.1"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Resolves **all 9 high-severity** npm-audit findings and the open Dependabot alerts across transitive dev/runtime dependencies.
- npm audit: **28 → 8** total (remaining 8 are documented accepted-risk / deferred — see below).
- S360/ADO query skipped this run (`az devops` not authenticated for the `dynamicscrm` org); fix plan derived from Dependabot + npm audit.

## Dependencies updated

| Package | Before | After | Strategy | Source |
| ------- | ------ | ----- | -------- | ------ |
| serialize-javascript | ^7.0.3 | ^7.0.5 | bump override | Dependabot #179 + npm |
| postcss | ^8.4.31 | ^8.5.15 | bump override | Dependabot #173 + npm |
| qs | ^6.14.2 | ^6.15.2 | bump override | Dependabot #180 + npm |
| basic-ftp | ^5.3.0 | ^6.0.1 | bump override | npm audit |
| tmp | 0.2.5 | ^0.2.7 | new override | Dependabot #181 + npm |
| undici | 6.23.0 | ^6.24.0 | new override | Dependabot #152/153/156 + npm |
| defu | 6.1.4 | ^6.1.7 | new override | npm audit |
| flatted | 3.4.1 | ^3.4.2 | new override | npm audit |
| form-data | 2.5.5 | ^2.5.6 | new override | npm audit |
| ip-address | 10.1.0 | ^10.2.0 | new override | npm audit |
| js-yaml | 4.1.1 | ^4.2.0 | new override | npm audit |
| lodash | 4.17.23 | ^4.18.1 | new override | npm audit |
| picomatch (under tinyglobby) | 4.0.3 | ^4.0.4 | scoped override | Dependabot #161 + npm |
| uuid (under tfx-cli) | 13.0.0 | ^13.0.1 | scoped override | Dependabot #174 + npm |
| tar | ^7.5.11 | ^7.5.16 | direct dep bump | npm audit |
| follow-redirects | 1.15.11 | 1.16.0 | **lock-file patch** | Dependabot #170 + npm |

**Why scoped/lock-patch:** `picomatch` and `uuid` each have an `inBundle` sibling (picomatch 2.3.2, uuid 3.4.0) that must not be force-upgraded, so scoped overrides target only the vulnerable nested copies. `follow-redirects` is `inBundle` via the bundled `cli-wrapper` subtree, so an override cannot reach it — patched directly in `package-lock.json` to 1.16.0.

## Known limitations / follow-ups
- **uuid 3.4.0 (runtime, Dependabot #178 / moderate)** — bundled inside `azure-pipelines-task-lib` (requires `uuid ^3.0.1`). Fixing needs uuid v3→v11 (breaking API) and the package is bundled in the VSIX, so an override cannot reach it. **Must be fixed upstream in `azure-pipelines-task-lib`.** Deferred.
- **elliptic chain** (browserify-sign, create-ecdh, crypto-browserify, node-libs-browser, rewiremock) — known permanent accepted risk (GHSA-848j-6mx2-7j84, LOW), dev-only, no patched version.

## Test plan
- [x] `npm install` clean
- [x] `npm audit` — 28 → 8 (all highs resolved; remaining are documented accepted-risk/deferred)
- [x] `npm run ci` — compile (32 tasks) + lint + restore pass. `unitTest` fails locally only on **Node 24** (`ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`, native TS strip vs CJS `ts-node/register`) — reproduces identically on clean `main`; CI runs Node 20 where it passes. Not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)