### PR TITLE
chore: fix uuid vulnerability (CVE-2026-41907)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/powerplatform-cli-wrapper": "^0.1.135",
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.277.0",
         "brace-expansion": "^2.0.3",
         "debug": "^4.3.5",
         "fs-extra": "^11.3.4",
@@ -2576,9 +2576,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha512-JrPLrurMxxhCEFP9LXls2AkuM8468kW5j44vyUE46DOUIBFnmIficj5dmgFA9Bc/nUtH4GcdcDSr23BzrJr1gw==",
+      "version": "5.277.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha512-QS9mHHBgNyX/Vfcdsz8IPlTOudLnPCrundLjm4b9Kq5oRvuCsHxcdLGwNf8yLTAgX7nzf0P4c+P0+H05RLT1qw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2587,8 +2587,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/semver": {
@@ -13133,17 +13132,6 @@
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@microsoft/powerplatform-cli-wrapper": "^0.1.135",
-    "azure-pipelines-task-lib": "^5.2.8",
+    "azure-pipelines-task-lib": "^5.277.0",
     "brace-expansion": "^2.0.3",
     "debug": "^4.3.5",
     "fs-extra": "^11.3.4",


### PR DESCRIPTION
## Summary

Cherry-pick of #1418 to `release/stable`.

- Upgrades `azure-pipelines-task-lib` 5.2.8 -> 5.277.0, which drops the transitive vulnerable `uuid@3.4.0` (CVE-2026-41907 / Dependabot #178).

## Paired main PR
#1418

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>