### PR TITLE
fix: pin azure-pipelines-task-lib to 5.276.0 (unblock official build)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/powerplatform-cli-wrapper": "^0.1.135",
-        "azure-pipelines-task-lib": "^5.277.0",
+        "azure-pipelines-task-lib": "5.276.0",
         "brace-expansion": "^2.0.3",
         "debug": "^4.3.5",
         "fs-extra": "^11.3.4",
@@ -2576,9 +2576,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.277.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
-      "integrity": "sha512-QS9mHHBgNyX/Vfcdsz8IPlTOudLnPCrundLjm4b9Kq5oRvuCsHxcdLGwNf8yLTAgX7nzf0P4c+P0+H05RLT1qw==",
+      "version": "5.276.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.276.0.tgz",
+      "integrity": "sha512-ohzFft3E/jS46VQ+PeC36mleq6gfI4GN7r8jzOS+o2d8yGYfSP07hS7opa+o/9j4JTDLTKviFd3V1EJl5p/jYg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@microsoft/powerplatform-cli-wrapper": "^0.1.135",
-    "azure-pipelines-task-lib": "^5.277.0",
+    "azure-pipelines-task-lib": "5.276.0",
     "brace-expansion": "^2.0.3",
     "debug": "^4.3.5",
     "fs-extra": "^11.3.4",


### PR DESCRIPTION
## Summary
- Follow-up fix to PR #1418. That PR merged `azure-pipelines-task-lib@^5.277.0`, which **breaks the official build** `PowerPlatform-DPX-Tools-GitHub-BT-Official`.
- The official pipeline restores dependencies from the internal **DPX-Tools-Upstream** Azure Artifacts feed, which does **not** carry `5.277.0` (npm `404` on the `NPM: Pre-install cli-wrapper` task, skipping all downstream stages).
- The feed **does** carry `5.276.0`, which likewise **drops the transitive `uuid` dependency**, so `uuid@3.4.0` (CVE-2026-41907) stays removed from the tree.
- Pinned **exactly** (no caret) so `npm install`/`npm ci` cannot re-resolve back to the feed-missing `5.277.0`.

## Dependencies updated

| Package | Before | After | Reason |
| ------- | ------ | ----- | ------ |
| azure-pipelines-task-lib | ^5.277.0 | 5.276.0 (pinned) | 5.277.0 absent from DPX-Tools-Upstream feed; 5.276.0 present and also drops vulnerable uuid |

## Verification
- Feed packument confirmed to contain 5.276.0 (and its new transitive deps: shelljs 0.10.0, nodejs-file-downloader, adm-zip); 5.277.0 absent.
- `npm ls uuid` -> only tfx-cli's patched 13.0.2; zero uuid@3.4.0.
- Lock pins 5.276.0; zero 5.277.0 references.

## Test plan
- [x] `npm install` clean
- [x] `npm run build` (compile + webpack) passes
- [ ] Re-queue official ADO build to confirm feed restore succeeds

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>