### PR TITLE
fix: pin azure-pipelines-task-lib to 5.276.0 (unblock official build)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/powerplatform-cli-wrapper": "^0.1.135",
-        "azure-pipelines-task-lib": "^5.277.0",
+        "azure-pipelines-task-lib": "5.276.0",
         "brace-expansion": "^2.0.3",
         "debug": "^4.3.5",
         "fs-extra": "^11.3.4",
@@ -2576,9 +2576,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.277.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
-      "integrity": "sha512-QS9mHHBgNyX/Vfcdsz8IPlTOudLnPCrundLjm4b9Kq5oRvuCsHxcdLGwNf8yLTAgX7nzf0P4c+P0+H05RLT1qw==",
+      "version": "5.276.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.276.0.tgz",
+      "integrity": "sha512-ohzFft3E/jS46VQ+PeC36mleq6gfI4GN7r8jzOS+o2d8yGYfSP07hS7opa+o/9j4JTDLTKviFd3V1EJl5p/jYg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@microsoft/powerplatform-cli-wrapper": "^0.1.135",
-    "azure-pipelines-task-lib": "^5.277.0",
+    "azure-pipelines-task-lib": "5.276.0",
     "brace-expansion": "^2.0.3",
     "debug": "^4.3.5",
     "fs-extra": "^11.3.4",


### PR DESCRIPTION
## Summary

Cherry-pick of #1420 to `release/stable`.

- PR #1419 merged `azure-pipelines-task-lib@^5.277.0` into `release/stable`, which breaks the official build (the `DPX-Tools-Upstream` feed lacks 5.277.0 -> npm 404).
- Pins to `5.276.0` (present in the feed), which also drops the transitive `uuid@3.4.0` (CVE-2026-41907). Pinned exactly so npm cannot re-resolve to 5.277.0.

## Paired main PR
#1420

## Verification
- Lock pins 5.276.0; zero 5.277.0 and zero uuid@3.4.0 references.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>