### PR TITLE
chore: update pac CLI to 2.10.1

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -22,7 +22,7 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 # Release Notes
 
 {{NextReleaseVersion}}:
-- pac CLI 2.7, [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.7.4#releasenotes-body-tab) (revert from 2.8.1)
+- pac CLI 2.10, [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.10.1#releasenotes-body-tab)
 
 2.0.145:
 - pac CLI 2.8, [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.8.1#releasenotes-body-tab)

--- a/nuget.json
+++ b/nuget.json
@@ -2,13 +2,13 @@
   "packages": [
     {
       "name": "Microsoft.PowerApps.CLI",
-      "version": "2.7.4",
+      "version": "2.10.1",
       "internalName": "pac",
       "useFeed": "nuget.org"
     },
     {
       "name": "Microsoft.PowerApps.CLI.Core.linux-x64",
-      "version": "2.7.4",
+      "version": "2.10.1",
       "internalName": "pac_linux",
       "chmod": "tools/pac",
       "useFeed": "nuget.org"


### PR DESCRIPTION
## Summary
- Bump PAC CLI from `2.7.4` to `2.10.1`
- Include the Power Pages fix for cross-environment SDM uploads not deleting stale many-to-many relationship links
- [PAC CLI 2.10.1 release notes](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.10.1#releasenotes-body-tab)

## Business impact
PPBT `2.0.150` still embeds PAC CLI `2.7.4`, so Azure DevOps customers cannot consume the M2M deletion fix released in PAC CLI `2.10.1`.

Without this bump, cross-environment Power Pages ALM deployments can complete while obsolete relationships remain in QA or Production. For example, removing a table-permission-to-web-role association in source does not remove it from the target, leaving silent configuration drift and requiring manual remediation. This can also retain an outdated security association after a deployment that otherwise appears successful.

An on-demand PPBT release is required because publishing the standalone PAC CLI package does not update the PAC binary bundled in PPBT tasks.

## Changes
- `nuget.json`: update both `Microsoft.PowerApps.CLI` and `Microsoft.PowerApps.CLI.Core.linux-x64` to `2.10.1`
- `extension/overview.md`: update the next-release PAC CLI entry to `2.10.1`
- `@microsoft/powerplatform-cli-wrapper`: unchanged

## Validation
- [x] Confirmed Windows and Linux PAC CLI `2.10.1` packages are published on NuGet
- [x] `npm install` completed with the locked wrapper dependency (`0.1.135`)
- [x] Compile and lint passed under Node `20.20.2`
- [x] Both PAC packages restored from NuGet at `2.10.1`
- [x] 45 unit tests passed
- [x] VSIX packaging completed; bundled Windows PAC reports `2.10.1+g52c3983`
- [ ] Credential-backed functional tests require the release pipeline environment and are intentionally left to CI

## Release safety
This PR intentionally changes only two files. The paired `release/stable` PR will cherry-pick only this commit; it will not merge all of `main` into `release/stable` (the source of the earlier conflict/rework).

CC @jbujula @priyanshu92

## CI infrastructure blocker
GitHub Actions is currently blocked before build by repository infrastructure unrelated to this two-file change:

- `GPR_ACCESS_TOKEN` cannot authenticate to `@microsoft/powerplatform-cli-wrapper@0.1.135` (`npm E401`)
- The same package-auth failure occurred on the preceding unrelated PR run on July 26
- CodeQL v2 deprecation is addressed separately by #1431 (pending merge)

The local validation above completed compile, lint, NuGet restore, unit tests, and VSIX packaging successfully. Per the release workflow, the paired `release/stable` PR will be created after the main PR check is green; a maintainer needs to refresh the package token (and separately move CodeQL to v3) first.