### PR TITLE
ci: upgrade CodeQL Action v2 -> v4 (deprecation maintenance)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -73,6 +73,6 @@ jobs:
       run: npm run build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -73,6 +73,6 @@ jobs:
       run: npm run build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

Upgrades `github/codeql-action/init` and `github/codeql-action/analyze` from **v2 to v4** in `.github/workflows/codeql.yml`. Two-line change, isolated from any product code.

## Why

CodeQL Action v1/v2 were [deprecated in January 2025](https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/). Every CodeQL run on this repo currently logs:

```
##[error]CodeQL Action major versions v1 and v2 have been deprecated.
Please update all occurrences of the CodeQL Action in your workflow files to v3.
```

This is **not currently fatal** - the Analyze job still succeeds - but it is emitted as an error on every run, and will hard-fail once GitHub completes enforcement. This PR gets ahead of that. The repo is currently two major versions behind.

## Correction to the earlier description

An earlier version of this description claimed CodeQL Action v2 was causing CodeQL checks to fail on #1430. **That was incorrect.**

Attempts 1 and 2 of the CodeQL run on #1430 both failed at the `Install npm dependencies` step with `npm E401` on `GPR_ACCESS_TOKEN` - the same root cause as the `build` job failures. After that secret was rotated, attempt 3 passed on `codeql-action@v2` with no workflow change.

So this PR is **pre-emptive maintenance**, not a fix for a live failure. It is not blocking anything and can be merged whenever convenient.

## Validation

- [x] All `github/codeql-action` references in `codeql.yml` now use `@v4`
- [x] Workflow YAML diff passes `git diff --check`
- [x] Hosted runner accepted `@v4` and ran the workflow through to the dependency step

## Note on remaining deprecations

`codeql.yml` also still uses `actions/checkout@v3` and `actions/setup-node@v3`, which emit Node 20 deprecation warnings. Those are left untouched here to keep this diff minimal, but are worth a follow-up.

Related: #1430