### PR TITLE
[release] Update pac CLI to 2.10.1

### DIFF
--- a/extension/overview.md
+++ b/extension/overview.md
@@ -22,7 +22,7 @@ Please use the issues tracker in the home repo: <https://github.com/microsoft/po
 # Release Notes
 
 {{NextReleaseVersion}}:
-- pac CLI 2.7, [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.7.4#releasenotes-body-tab) (revert from 2.8.1)
+- pac CLI 2.10, [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.10.1#releasenotes-body-tab)
 
 2.0.145:
 - pac CLI 2.8, [Release Notes on nuget.org](https://www.nuget.org/packages/Microsoft.PowerApps.CLI/2.8.1#releasenotes-body-tab)

--- a/nuget.json
+++ b/nuget.json
@@ -2,13 +2,13 @@
   "packages": [
     {
       "name": "Microsoft.PowerApps.CLI",
-      "version": "2.7.4",
+      "version": "2.10.1",
       "internalName": "pac",
       "useFeed": "nuget.org"
     },
     {
       "name": "Microsoft.PowerApps.CLI.Core.linux-x64",
-      "version": "2.7.4",
+      "version": "2.10.1",
       "internalName": "pac_linux",
       "chmod": "tools/pac",
       "useFeed": "nuget.org"


### PR DESCRIPTION
## Summary

Cherry-picks the PAC CLI `2.10.1` bump onto `release/stable`. Paired release PR for #1430 (base `main`).

## Changes

- `nuget.json`: `Microsoft.PowerApps.CLI` and `Microsoft.PowerApps.CLI.Core.linux-x64` `2.7.4` -> `2.10.1`
- `extension/overview.md`: `{{NextReleaseVersion}}` entry updated to pac CLI 2.10

Single cherry-picked commit (`a70d979`), 2 files, +3/-3. `main` was **not** merged into `release/stable`, so there is no lockfile churn.

## Why 2.10.1

Ships the many-to-many relationship fix for cross-environment `pac pages upload` on SDM sites. PPBT has been pinned at `2.7.4` since the 2.8.1 revert.

## Validation

Run locally against the same commit on the `main` branch (Node 20.20.2):

- [x] Both `2.10.1` NuGet packages confirmed published (win + linux-x64)
- [x] `npm install`, compile, lint
- [x] `gulp restore` downloaded PAC `2.10.1` for both platforms
- [x] 45 unit tests passing
- [x] VSIX packaged; staged `pac.exe` reports `2.10.1+g52c3983`
- [ ] functional tests - require `PA_BT_ORG_PASSWORD`, not run locally

## CI blocker (pre-existing, not caused by this change)

`GPR_ACCESS_TOKEN` is returning `npm E401` on `@microsoft/powerplatform-cli-wrapper`. The secret was last updated 2026-07-08; the last green run was 2026-07-09 and the repo has been red since ~2026-07-18. This affects every PR, not just this one.

Rotating the PAT unblocks it short-term. The durable fix is to grant `powerplatform-build-tools` **Read** under *Manage Actions access* on the `powerplatform-cli-wrapper` package, so CI can authenticate with the built-in `GITHUB_TOKEN` instead of a PAT that keeps expiring.

## Note

Raised at Jayanth's request, ahead of `main` CI going green (the repo skill normally requires main CI to pass first).