### PR TITLE
fix(ci): degrade gracefully when Actions may not open PRs

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -110,6 +110,33 @@ jobs:
           # No --assignee / --reviewer here: .github/CODEOWNERS already requests a review from
           # @microsoft/managed-app-devops-team for every file this PR touches, and passing a
           # team reviewer explicitly can fail depending on the GITHUB_TOKEN's permissions.
-          gh pr create --base main --head "$BRANCH" \
-            --title "chore: weekly dependency security refresh" \
-            --body-file pr-body.md
+          #
+          # Actions cannot open a PR when the org/repo policy "Allow GitHub Actions to create
+          # and approve pull requests" is disabled. By this point the branch is pushed and the
+          # build is green, so the work is not lost. Failing the run would put a red X on the
+          # weekly job every week for a reason nobody can fix from the workflow, which just
+          # trains people to ignore it. Surface an actionable link instead.
+          if ! gh pr create --base main --head "$BRANCH" \
+                --title "chore: weekly dependency security refresh" \
+                --body-file pr-body.md 2> pr-error.log; then
+            cat pr-error.log >&2
+            if grep -q "not permitted to create or approve pull requests" pr-error.log; then
+              echo "::warning::Branch '$BRANCH' was pushed and is green, but Actions is not allowed to open PRs in this repo. Open it manually, or enable Settings > Actions > General > 'Allow GitHub Actions to create and approve pull requests'."
+              {
+                echo "## Dependency refresh is ready, but the PR could not be opened automatically"
+                echo
+                echo "Branch \`$BRANCH\` has been pushed and \`npm run ci\` passed."
+                echo
+                echo "**Open the PR:** https://github.com/${GITHUB_REPOSITORY}/compare/main...${BRANCH}?expand=1"
+                echo
+                echo "To let future runs open it themselves, enable **Settings > Actions > General >"
+                echo "\"Allow GitHub Actions to create and approve pull requests\"**."
+                echo
+                echo "---"
+                echo
+                cat pr-body.md
+              } >> "$GITHUB_STEP_SUMMARY"
+            else
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
Follow-up to #1441, found by actually running the new workflow instead of assuming it worked.

Run: https://github.com/microsoft/powerplatform-build-tools/actions/runs/31760462499

## What happened

Every meaningful step passed - `npm ci`, `npm update`, `audit-overrides.js`, and **`npm run ci` (build + test)** - and the branch was pushed. Then the final step failed:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

That is the repo/org policy **Settings > Actions > General > "Allow GitHub Actions to create and approve pull requests"**, which is disabled here. It is not something the workflow can fix, and no token change helps - it applies to `GITHUB_TOKEN`-driven Actions runs regardless of `permissions:`.

The run was still valuable: I opened its output by hand as #1461, which upgrades **`nanoid` 3.3.17 -> 3.3.18**, clearing **GHSA-2v37-7h3g-55p8** (HIGH). That is the advisory I had documented on #1433, #1440 and #506 as "not fixable yet" because `3.3.18` was not mirrored on `packagefeedproxy.microsoft.io`. The mirror synced, and the automation caught it on its first run with zero human input - which is precisely the Dependabot blind spot (`overrides`-pinned transitives) this was built for.

## The change

Failing the whole run for a policy the workflow cannot satisfy would put a red X on the weekly job **every week**, which reliably trains people to stop looking at it. But silently passing would hide real breakage. So the step now distinguishes the two:

| Outcome | Behavior |
|---|---|
| The policy error | `::warning::` + job summary with a prefilled compare link and the full PR body, exit **0** |
| Any other error | stderr printed, exit **1** (unchanged) |

The underlying `gh` error is printed in both cases. Because the branch is already pushed and green at that point, the work is recoverable in one click from the summary.

If an admin enables the setting, nothing here needs to change - future runs will simply open their own PRs and never hit the fallback.

## Verification

Tested with a stubbed `gh` reproducing the exact stderr:

- policy error -> warning emitted, summary written with the compare URL, **exit 0**
- unrelated error (`some other unrelated API error`) -> **exit 1**, fallback not triggered, so genuine failures are not masked
- `yaml.load` parses the workflow; `bash -n` clean on the extracted step script
